### PR TITLE
Enable scan for pre and post fulu states

### DIFF
--- a/api/state.go
+++ b/api/state.go
@@ -17,18 +17,18 @@ type PeerDASstate struct {
 	Data                electra.BeaconState `json:"data"`
 }
 
-func (c *Client) GetPeerDASstate(ctx context.Context) (PeerDASstate, error) {
+func (c *Client) GetPeerDASstate(ctx context.Context) (*PeerDASstate, error) {
 	var state PeerDASstate
 
 	resp, err := c.get(ctx, c.cfg.QueryTimeout, BeaconStateBase, "")
 	if err != nil {
-		return state, errors.Wrap(err, "requesting beacon-state")
+		return &state, errors.Wrap(err, "requesting beacon-state")
 	}
 
 	err = json.Unmarshal(resp, &state)
 	if err != nil {
-		return state, errors.Wrap(err, "unmarshaling beacon-state from http request")
+		return &state, errors.Wrap(err, "unmarshaling beacon-state from http request")
 	}
 
-	return state, nil
+	return &state, nil
 }

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -11,10 +11,8 @@ import (
 
 var monitorConfig = struct {
 	MonitorFrequency time.Duration
-	MonitorDuration  time.Duration
 }{
 	MonitorFrequency: 1 * time.Minute,
-	MonitorDuration:  10 * time.Minute,
 }
 
 var cmdMonitor = &cli.Command{
@@ -32,18 +30,11 @@ var monitorFlags = []cli.Flag{
 		Value:       monitorConfig.MonitorFrequency,
 		Destination: &monitorConfig.MonitorFrequency,
 	},
-	&cli.DurationFlag{
-		Name:        "duration",
-		Usage:       "Duration of the whole monitoring process ['5m', '1h']",
-		Value:       monitorConfig.MonitorDuration,
-		Destination: &monitorConfig.MonitorDuration,
-	},
 }
 
 func monitorAction(ctx context.Context, cmd *cli.Command) error {
 	log.WithFields(log.Fields{
-		"freq":     monitorConfig.MonitorFrequency,
-		"duration": monitorConfig.MonitorDuration,
+		"freq": monitorConfig.MonitorFrequency,
 	}).Info("monitor cmd...")
 
 	ethConfig := &dasguardian.DasGuardianConfig{

--- a/custody_test.go
+++ b/custody_test.go
@@ -1,0 +1,9 @@
+package dasguardian
+
+import "testing"
+
+func Test_ComputeForkDigest(t *testing.T) {
+}
+
+func Test_ComputeForkDigestFulu(t *testing.T) {
+}

--- a/guardian.go
+++ b/guardian.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"sync"
@@ -148,9 +149,16 @@ type DasGuardian struct {
 	rpcServ *ReqResp
 
 	// chain data
-	headState    *api.PeerDASstate
-	headStatus   pb.StatusV2
-	headMetadata pb.MetaDataV2
+	stateM sync.RWMutex
+	state  *api.PeerDASstate
+
+	// pre-fulu
+	electraStatus   pb.Status
+	electraMetadata pb.MetaDataV1
+
+	// post-fulu
+	fuluStatus   pb.StatusV2
+	fuluMetadata pb.MetaDataV2
 }
 
 func NewDASGuardian(ctx context.Context, cfg *DasGuardianConfig) (*DasGuardian, error) {
@@ -188,9 +196,7 @@ func NewDASGuardian(ctx context.Context, cfg *DasGuardianConfig) (*DasGuardian, 
 		apiCli: apiCli,
 	}
 
-	initCtx, initCancel := context.WithTimeout(ctx, cfg.InitTimeout)
-	defer initCancel()
-	if err := guardian.init(initCtx); err != nil {
+	if err := guardian.init(ctx); err != nil {
 		return nil, err
 	}
 
@@ -198,21 +204,26 @@ func NewDASGuardian(ctx context.Context, cfg *DasGuardianConfig) (*DasGuardian, 
 }
 
 func (g *DasGuardian) init(ctx context.Context) error {
+	initCtx, initCancel := context.WithTimeout(ctx, g.cfg.InitTimeout)
+	defer initCancel()
+
 	// check api connection
-	if err := g.apiCli.CheckConnection(ctx); err != nil {
+	if err := g.apiCli.CheckConnection(initCtx); err != nil {
 		return fmt.Errorf("connection to %s was stablished, but not active - %s", g.cfg.BeaconAPIendpoint, err.Error())
 	}
 	log.Info("connected to the beacon API...")
 
 	// get the network configuration from the apiCli
-	forkSchedules, err := g.apiCli.GetNetworkConfig(ctx)
+	forkSchedules, err := g.apiCli.GetNetworkConfig(initCtx)
 	if err != nil {
 		return err
 	}
 	g.forkSchedules = forkSchedules.Data[FuluForkScheduleIdx] // we only need the fulu specifics
 
 	// compose and get the local Metadata
-	currentState, err := g.apiCli.GetPeerDASstate(ctx)
+	g.stateM.Lock()
+	g.state, err = g.apiCli.GetPeerDASstate(initCtx)
+	g.stateM.Unlock()
 	if err != nil {
 		return err
 	}
@@ -221,71 +232,72 @@ func (g *DasGuardian) init(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if (int(currentState.Data.Slot) / 32) < fuluForkEpoch {
-		secondsToFulu := time.Duration(((fuluForkEpoch*32)-int(currentState.Data.Slot))*12) * time.Second
+	g.stateM.RLock()
+	currentSlot := int(g.state.Data.Slot)
+	currentVersion := g.state.Version
+	g.stateM.RUnlock()
+	if (currentSlot / 32) < fuluForkEpoch {
+		secondsToFulu := time.Duration(((fuluForkEpoch*32)-currentSlot)*12) * time.Second
 		log.Warnf("network doesn't support fulu yet")
-		log.Warnf("current: (slot: %d epoch: %d - version: %s)", currentState.Data.Slot, (currentState.Data.Slot / 32), currentState.Version)
-		log.Warnf("target:  (slot: %d epoch: %d - missing: %d = %s)", fuluForkEpoch*32, fuluForkEpoch, (fuluForkEpoch*32)-int(currentState.Data.Slot), secondsToFulu)
-		if g.cfg.WaitForFulu {
+		log.Warnf("current: (slot: %d epoch: %d - version: %s)", currentSlot, (currentSlot / 32), currentVersion)
+		log.Warnf("target:  (slot: %d epoch: %d - missing: %d = %s)", fuluForkEpoch*32, fuluForkEpoch, (fuluForkEpoch*32)-currentSlot, secondsToFulu)
+		go func() {
 			log.Info("waiting for ", secondsToFulu)
 			if secondsToFulu < 0 {
-				return fmt.Errorf("neg time to fulu?!")
+				log.Error("neg time to fulu?!")
+				return
 			}
 			select {
 			case <-ctx.Done():
-				return fmt.Errorf("tooled closed without reaching fulu upgrade")
+				log.Error("tooled closed without reaching fulu upgrade")
+				return
 
 			case <-time.After(secondsToFulu):
-				currentState, err = g.apiCli.GetPeerDASstate(ctx)
+				g.stateM.Lock()
+				g.state, err = g.apiCli.GetPeerDASstate(ctx)
+				g.stateM.Unlock()
 				if err != nil {
-					return err
+					log.Errorf("unable to get the Beacon State after Fulu - %s", err.Error())
+					return
 				}
 			}
-		} else {
-			return fmt.Errorf("network doesn't support fulu yet (slot: %d - %s)", currentState.Data.Slot, currentState.Version)
-		}
+		}()
 	} else {
 		log.Info("fulu is supported")
-		fmt.Sprintln((int(currentState.Data.Slot) / 32), fuluForkEpoch)
+		fmt.Sprintln(currentSlot/32, fuluForkEpoch)
 	}
 
+	g.stateM.RLock()
 	prettyLogrusFields("dowloaded beacon head-state", map[string]any{
-		"version":       currentState.Version,
-		"finalized":     currentState.Finalized,
-		"optimistic-el": currentState.ExecutionOptimistic,
-		"validators":    len(currentState.Data.Validators),
+		"version":       g.state.Version,
+		"finalized":     g.state.Finalized,
+		"optimistic-el": g.state.ExecutionOptimistic,
+		"validators":    len(g.state.Data.Validators),
 	})
+	g.stateM.RUnlock()
 
-	status, err := g.composeLocalBeaconStatus(&currentState)
+	err = g.composeLocalBeaconStaus()
 	if err != nil {
 		return err
 	}
-	prettyLogrusFields("local beacon-status", map[string]any{
-		"head-slot":   status.HeadSlot,
-		"fork-digest": fmt.Sprintf("0x%x", status.ForkDigest),
-	})
-	g.headState = &currentState
-	g.headStatus = status
-	g.headMetadata = g.composeLocalBeaconMetadata()
 
 	// subscribe to main topics
-	if err = g.subscribeToTopics(ctx, getMandatoryTopics(currentState.Data.Fork.String())); err != nil {
+	forkD := g.state.Data.Fork.String()
+	if err = g.subscribeToTopics(initCtx, getMandatoryTopics(forkD)); err != nil {
 		return err
 	}
 
 	// register the rpc module
 	reqRespCfg := &ReqRespConfig{
-		Encoder:        &encoder.SszNetworkEncoder{},
-		ReadTimeout:    g.cfg.ConnectionTimeout,
-		WriteTimeout:   g.cfg.ConnectionTimeout,
-		BeaconStatus:   g.headStatus,
-		BeaconMetadata: g.headMetadata,
+		Encoder:      &encoder.SszNetworkEncoder{},
+		ReadTimeout:  g.cfg.ConnectionTimeout,
+		WriteTimeout: g.cfg.ConnectionTimeout,
 	}
 	reqResp, err := NewReqResp(g.host, reqRespCfg)
 	if err != nil {
 		return err
 	}
-	if err := reqResp.RegisterHandlers(ctx); err != nil {
+	if err := reqResp.RegisterHandlers(initCtx); err != nil {
 		return err
 	}
 	g.rpcServ = reqResp
@@ -361,6 +373,69 @@ func (g *DasGuardian) ScanMultiple(ctx context.Context, concurrency int32, ethNo
 }
 
 func (g *DasGuardian) scan(ctx context.Context, ethNode *enode.Node) (DASEvaluationResult, error) {
+	// scan based on the fork_version or state_version
+	g.stateM.RLock()
+	defer g.stateM.RUnlock()
+	// check if we are pre or post fulu
+	switch g.state.Version {
+	case "electra":
+		return g.scanElectra(ctx, ethNode)
+	case "fulu":
+		return g.scanFulu(ctx, ethNode)
+	default:
+		return DASEvaluationResult{}, fmt.Errorf("not recognized fork for the state %s", g.state.Version)
+	}
+
+}
+
+func (g *DasGuardian) scanElectra(ctx context.Context, ethNode *enode.Node) (DASEvaluationResult, error) {
+	// get the info from the ENR
+	enodeAddr, err := ParseMaddrFromEnode(ethNode)
+	if err != nil {
+		return DASEvaluationResult{}, err
+	}
+
+	// connection attempt using the libp2p host
+	if err := g.ConnectNode(ctx, enodeAddr); err != nil {
+		return DASEvaluationResult{}, err
+	}
+
+	// extract the necessary information from the ethNode
+	libp2pInfo := g.libp2pPeerInfo(enodeAddr.ID)
+
+	// exchange ping
+	startT := time.Now()
+	if err := g.rpcServ.Ping(ctx, enodeAddr.ID); err != nil {
+		return DASEvaluationResult{}, nil
+	}
+	libp2pInfo["ping_rtt"] = time.Since(startT)
+	prettyLogrusFields("libp2p info...", libp2pInfo)
+
+	// exchange beacon-status
+	remoteStatus := g.requestBeaconStatusV1(ctx, enodeAddr.ID)
+	if remoteStatus == nil {
+		return DASEvaluationResult{}, fmt.Errorf("failed to get beacon status from peer %s", enodeAddr.ID)
+	}
+	statusLogs := g.visualizeBeaconStatusV1(remoteStatus)
+
+	// exchange beacon-metadata
+	remoteMetadata := g.requestBeaconMetadataV2(ctx, enodeAddr.ID)
+	if remoteMetadata == nil {
+		return DASEvaluationResult{}, fmt.Errorf("failed to get beacon metadata from peer %s", enodeAddr.ID)
+	}
+	metadataLogs := g.visualizeBeaconMetadataV2(remoteMetadata)
+
+	prettyLogrusFields("scanning eth-node...", map[string]any{
+		"peer-id": enodeAddr.ID.String(),
+		"maddr":   enodeAddr.Addrs,
+	})
+	prettyLogrusFields("beacon status...", statusLogs)
+	prettyLogrusFields("beacon metadata...", metadataLogs)
+
+	return DASEvaluationResult{}, nil
+}
+
+func (g *DasGuardian) scanFulu(ctx context.Context, ethNode *enode.Node) (DASEvaluationResult, error) {
 	// get the info from the ENR
 	enodeAddr, err := ParseMaddrFromEnode(ethNode)
 	if err != nil {
@@ -393,18 +468,18 @@ func (g *DasGuardian) scan(ctx context.Context, ethNode *enode.Node) (DASEvaluat
 	prettyLogrusFields("libp2p info...", libp2pInfo)
 
 	// exchange beacon-status
-	remoteStatus := g.requestBeaconStatus(ctx, enodeAddr.ID)
+	remoteStatus := g.requestBeaconStatusV2(ctx, enodeAddr.ID)
 	if remoteStatus == nil {
 		return DASEvaluationResult{}, fmt.Errorf("failed to get beacon status from peer %s", enodeAddr.ID)
 	}
-	statusLogs := g.visualizeBeaconStatus(remoteStatus)
+	statusLogs := g.visualizeBeaconStatusV2(remoteStatus)
 
 	// exchange beacon-metadata
-	remoteMetadata := g.requestBeaconMetadata(ctx, enodeAddr.ID)
+	remoteMetadata := g.requestBeaconMetadataV3(ctx, enodeAddr.ID)
 	if remoteMetadata == nil {
 		return DASEvaluationResult{}, fmt.Errorf("failed to get beacon metadata from peer %s", enodeAddr.ID)
 	}
-	metadataLogs := g.visualizeBeaconMetadata(remoteMetadata)
+	metadataLogs := g.visualizeBeaconMetadataV3(remoteMetadata)
 	metadataCustodyIdxs, err := CustodyColumnsSlice(ethNode.ID(), remoteMetadata.CustodyGroupCount, DataColumnSidecarSubnetCount, DataColumnSidecarSubnetCount)
 	if err != nil {
 		return DASEvaluationResult{}, errors.Wrap(err, "wrong cuystody subnet")
@@ -471,7 +546,6 @@ func (g *DasGuardian) MonitorEndpoint(ctx context.Context) error {
 				return err
 			}
 		}
-
 	}
 }
 
@@ -607,7 +681,21 @@ func (g *DasGuardian) libp2pPeerInfo(pid peer.ID) map[string]any {
 	return libp2pMetadata
 }
 
-func (g *DasGuardian) visualizeBeaconStatus(status *pb.StatusV2) map[string]any {
+func (g *DasGuardian) visualizeBeaconStatusV1(status *pb.Status) map[string]any {
+	statusInfo := make(map[string]any)
+	if status != nil {
+		statusInfo[ForkDigest] = fmt.Sprintf("0x%x", status.ForkDigest)
+		statusInfo[FinalizedEpoch] = status.FinalizedEpoch
+		statusInfo[FinalizedRoot] = fmt.Sprintf("0x%x", status.FinalizedRoot)
+		statusInfo[HeadRoot] = fmt.Sprintf("0x%x", status.HeadRoot)
+		statusInfo[HeadSlot] = status.HeadSlot
+	} else {
+		statusInfo["beacon-status"] = "errored"
+	}
+	return statusInfo
+}
+
+func (g *DasGuardian) visualizeBeaconStatusV2(status *pb.StatusV2) map[string]any {
 	statusInfo := make(map[string]any)
 	if status != nil {
 		statusInfo[ForkDigest] = fmt.Sprintf("0x%x", status.ForkDigest)
@@ -622,15 +710,37 @@ func (g *DasGuardian) visualizeBeaconStatus(status *pb.StatusV2) map[string]any 
 	return statusInfo
 }
 
-func (g *DasGuardian) requestBeaconStatus(ctx context.Context, pid peer.ID) *pb.StatusV2 {
-	status, err := g.rpcServ.StatusV2(ctx, pid)
+func (g *DasGuardian) requestBeaconStatusV1(ctx context.Context, pid peer.ID) *pb.Status {
+	// TODO: probably better to lock the state here as well to read the status
+	status, err := g.rpcServ.StatusV1(ctx, pid, &g.electraStatus)
+	if err != nil {
+		log.Warnf("error requesting beacon-status-v1 - %s", err.Error())
+	}
+	return status
+}
+
+func (g *DasGuardian) requestBeaconStatusV2(ctx context.Context, pid peer.ID) *pb.StatusV2 {
+	// TODO: probably better to lock the state here as well to read the status
+	status, err := g.rpcServ.StatusV2(ctx, pid, &g.fuluStatus)
 	if err != nil {
 		log.Warnf("error requesting beacon-status-v2 - %s", err.Error())
 	}
 	return status
 }
 
-func (g *DasGuardian) visualizeBeaconMetadata(metadata *pb.MetaDataV2) map[string]any {
+func (g *DasGuardian) visualizeBeaconMetadataV2(metadata *pb.MetaDataV1) map[string]any {
+	metadataInfo := make(map[string]any)
+	if metadata != nil {
+		metadataInfo[SeqNumber] = metadata.SeqNumber
+		metadataInfo[Attnets] = fmt.Sprintf("0x%x", metadata.Attnets.Bytes())
+		metadataInfo[Syncnets] = fmt.Sprintf("0x%x", metadata.Syncnets.Bytes())
+	} else {
+		metadataInfo["beacon-metadata"] = "errored"
+	}
+	return metadataInfo
+}
+
+func (g *DasGuardian) visualizeBeaconMetadataV3(metadata *pb.MetaDataV2) map[string]any {
 	metadataInfo := make(map[string]any)
 	if metadata != nil {
 		metadataInfo[SeqNumber] = metadata.SeqNumber
@@ -643,49 +753,143 @@ func (g *DasGuardian) visualizeBeaconMetadata(metadata *pb.MetaDataV2) map[strin
 	return metadataInfo
 }
 
-func (g *DasGuardian) requestBeaconMetadata(ctx context.Context, pid peer.ID) *pb.MetaDataV2 {
-	metadata, err := g.rpcServ.MetaDataV3(ctx, pid)
+func (g *DasGuardian) requestBeaconMetadataV2(ctx context.Context, pid peer.ID) *pb.MetaDataV1 {
+	metadata, err := g.rpcServ.MetaDataV2(ctx, pid, &g.electraMetadata)
+	if err != nil {
+		log.Warnf("error requesting beacon-metadata-v2 - %s", err.Error())
+	}
+	return metadata
+}
+
+func (g *DasGuardian) requestBeaconMetadataV3(ctx context.Context, pid peer.ID) *pb.MetaDataV2 {
+	metadata, err := g.rpcServ.MetaDataV3(ctx, pid, &g.fuluMetadata)
 	if err != nil {
 		log.Warnf("error requesting beacon-metadata-v3 - %s", err.Error())
 	}
 	return metadata
 }
 
-func (g *DasGuardian) composeLocalBeaconStatus(state *api.PeerDASstate) (pb.StatusV2, error) {
+func (g *DasGuardian) composeLocalBeaconStaus() error {
+	// check if we are pre or post fulu
+	g.stateM.RLock()
+	defer g.stateM.RUnlock()
+	switch g.state.Version {
+	case "electra":
+		return g.composeElectraBeaconStatus()
+	case "fulu":
+		return g.composeFuluBeaconStatus()
+	default:
+		return fmt.Errorf("not recognized fork for the state %s", g.state.Version)
+	}
+}
+
+func (g *DasGuardian) composeElectraBeaconStatus() error {
+	// the composeBeaconStatus already has the rLock of the state
 	// fork digest
-	forkDigest, err := computeForkDigest(
-		state.Data.Fork.CurrentVersion[:],
-		state.Data.GenesisValidatorsRoot[:],
+	forkDigest, err := computePreFuluForkDigest(
+		g.state.Data.Fork.CurrentVersion[:],
+		g.state.Data.GenesisValidatorsRoot[:],
 	)
+	forkDigest, err = hex.DecodeString(g.state.Data.Fork.String())
 	if err != nil {
-		return pb.StatusV2{}, err
+		return err
 	}
 
 	// finalized
-	finalizedRoot := bytesutil.ToBytes32(state.Data.FinalizedCheckpoint.Root[:])
-	finalizedEpoch := primitives.Epoch(state.Data.FinalizedCheckpoint.Epoch)
+	finalizedRoot := bytesutil.ToBytes32(g.state.Data.FinalizedCheckpoint.Root[:])
+	finalizedEpoch := primitives.Epoch(g.state.Data.FinalizedCheckpoint.Epoch)
 
 	// head
-	headRoot := bytesutil.ToBytes32(state.Data.LatestBlockHeader.StateRoot[:])
-	headSlot := primitives.Slot(state.Data.LatestBlockHeader.Slot)
+	headRoot := bytesutil.ToBytes32(g.state.Data.LatestBlockHeader.StateRoot[:])
+	headSlot := primitives.Slot(g.state.Data.LatestBlockHeader.Slot)
 
-	return pb.StatusV2{
+	g.electraStatus = pb.Status{
+		ForkDigest:     forkDigest,
+		FinalizedRoot:  finalizedRoot[:],
+		FinalizedEpoch: finalizedEpoch,
+		HeadRoot:       headRoot[:],
+		HeadSlot:       headSlot,
+	}
+
+	prettyLogrusFields("local beacon-status", map[string]any{
+		"head-slot":   headSlot,
+		"fork-digest": fmt.Sprintf("0x%x", forkDigest),
+	})
+
+	return nil
+}
+
+func (g *DasGuardian) composeFuluBeaconStatus() error {
+	// TODO: fix this to support he BPO forks
+	forkDigest, err := computePreFuluForkDigest(
+		g.state.Data.Fork.CurrentVersion[:],
+		g.state.Data.GenesisValidatorsRoot[:],
+	)
+	// is this a hotfix?
+	forkDigest, err = hex.DecodeString("b62f2b0e")
+	if err != nil {
+		return err
+	}
+	if err != nil {
+		return err
+	}
+
+	// finalized
+	finalizedRoot := bytesutil.ToBytes32(g.state.Data.FinalizedCheckpoint.Root[:])
+	finalizedEpoch := primitives.Epoch(g.state.Data.FinalizedCheckpoint.Epoch)
+
+	// head
+	headRoot := bytesutil.ToBytes32(g.state.Data.LatestBlockHeader.StateRoot[:])
+	headSlot := primitives.Slot(g.state.Data.LatestBlockHeader.Slot)
+
+	g.fuluStatus = pb.StatusV2{
 		ForkDigest:            forkDigest,
 		FinalizedRoot:         finalizedRoot[:],
 		FinalizedEpoch:        finalizedEpoch,
 		HeadRoot:              headRoot[:],
 		HeadSlot:              headSlot,
 		EarliestAvailableSlot: headSlot,
-	}, nil
+	}
+
+	prettyLogrusFields("local beacon-status", map[string]any{
+		"head-slot":   headSlot,
+		"fork-digest": fmt.Sprintf("0x%x", forkDigest),
+	})
+
+	return nil
 }
 
-func (g *DasGuardian) composeLocalBeaconMetadata() pb.MetaDataV2 {
-	return pb.MetaDataV2{
+func (g *DasGuardian) composeLocalBeaconMetadata() error {
+	// check if we are pre or post fulu
+	g.stateM.RLock()
+	defer g.stateM.RUnlock()
+	switch g.state.Version {
+	case "electra":
+		return g.composeElectraMetadata()
+	case "fulu":
+		return g.composeFuluMetadata()
+	default:
+		return fmt.Errorf("not recognized fork for the state %s", g.state.Version)
+	}
+}
+
+func (g *DasGuardian) composeElectraMetadata() error {
+	g.electraMetadata = pb.MetaDataV1{
+		SeqNumber: 0,
+		Attnets:   bitfield.NewBitvector64(),
+		Syncnets:  bitfield.Bitvector4{byte(0x00)},
+	}
+	return nil
+}
+
+func (g *DasGuardian) composeFuluMetadata() error {
+	g.fuluMetadata = pb.MetaDataV2{
 		SeqNumber:         0,
 		Attnets:           bitfield.NewBitvector64(),
 		Syncnets:          bitfield.Bitvector4{byte(0x00)},
 		CustodyGroupCount: uint64(0),
 	}
+	return nil
 }
 
 func (g *DasGuardian) getDataColumnForSlotAndSubnet(ctx context.Context, pid peer.ID, slots []uint64, columnIdxs []uint64) ([][]*pb.DataColumnSidecar, error) {
@@ -701,7 +905,9 @@ func (g *DasGuardian) getDataColumnForSlotAndSubnet(ctx context.Context, pid pee
 	// make the request for each slots
 	for s, slot := range slots {
 		// make the request per each column
-		duration, cols, err := g.rpcServ.DataColumnByRangeV1(ctx, pid, slot, columnIdxs)
+		g.stateM.Lock()
+		duration, cols, err := g.rpcServ.DataColumnByRangeV1(ctx, pid, slot, columnIdxs, g.fuluStatus.ForkDigest)
+		g.stateM.RUnlock()
 		if err != nil {
 			log.Error(err)
 			return dataColumns, err
@@ -741,4 +947,18 @@ func (g *DasGuardian) fetchSlotBlocks(ctx context.Context, slots []uint64) ([]*a
 		}
 	}
 	return blocks, nil
+}
+
+func (g *DasGuardian) getCurrentForkDigest() string {
+	g.stateM.RLock()
+	defer g.stateM.RUnlock()
+	switch g.state.Version {
+	case "electra":
+		return string(g.electraStatus.ForkDigest)
+	case "fulu":
+		return string(g.fuluStatus.ForkDigest)
+	default:
+		return ""
+	}
+
 }

--- a/guardian.go
+++ b/guardian.go
@@ -804,7 +804,6 @@ func (g *DasGuardian) composeElectraBeaconStatus() error {
 		g.state.Data.Fork.CurrentVersion[:],
 		g.state.Data.GenesisValidatorsRoot[:],
 	)
-	forkDigest, err = hex.DecodeString(g.state.Data.Fork.String())
 	if err != nil {
 		return err
 	}

--- a/guardian_utils.go
+++ b/guardian_utils.go
@@ -9,7 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func computeForkDigest(forkV []byte, valRoots []byte) ([]byte, error) {
+func computePreFuluForkDigest(forkV []byte, valRoots []byte) ([]byte, error) {
 	r, err := (&pb.ForkData{
 		CurrentVersion:        forkV,
 		GenesisValidatorsRoot: valRoots,

--- a/guardinan_test.go
+++ b/guardinan_test.go
@@ -1,0 +1,58 @@
+package dasguardian
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testBeaconAPI = "https://beacon.fusaka-devnet-2.ethpandaops.io/"
+)
+
+func Test_DASGuardianClientInterop(t *testing.T) {
+	clients := map[string]string{
+		"lighthouse": "enr:-PO4QFAZca5TDfbiiCKouERBRao_oLgy5KCPvbezPfhTacxHWlBqfDgsfsghRLBUH9W8bj08v1jkd64UoUjSaWZx-6UHh2F0dG5ldHOIAAAAAAADAACDY2djgYCGY2xpZW502IpMaWdodGhvdXNljDcuMS4wLWJldGEuMIRldGgykIEAExpwk3VEAAEAAAAAAACCaWSCdjSCaXCEn99xd4NuZmSENp-J94RxdWljgiMpiXNlY3AyNTZrMaEDzVa77_o452OzzqylcK2mA0DREidLotbGonvz3nogDS-Ic3luY25ldHMPg3RjcIIjKIN1ZHCCIyg",
+		"prysm":      "enr:-Nm4QC89gsJ5_ndVJmiICaZpuebe7ppJbq2Y8Fz7xmICUCr3PYxIId-1hGLhP3cc7PwibKyQKcx2YNmCouMHH_QDXNaGAZesHoZVh2F0dG5ldHOIAAAAAAAAAAODY2djgYCEZXRoMpCBABMacJN1RAABAAAAAAAAgmlkgnY0gmlwhKdHVViDbmZkhDafifeEcXVpY4IyyIlzZWNwMjU2azGhAqi72ZtElLUzVdd7OdFlAFOjeCeQcoCGc8mugYAxD71tiHN5bmNuZXRzB4N0Y3CCIyiDdWRwgiMo",
+		"teku":       "enr:-Mu4QMDbGc5XAr9gHNuxzh3SMuAPlZgb92ANxqW_l0yj5rG9TFw-8WtV5Ce5GIrwVuXFKatMf7sEo8vPk-D5Ag0lx5kLh2F0dG5ldHOIAAAAAAAAAwCDY2djgYCEZXRoMpCBABMacJN1RAABAAAAAAAAgmlkgnY0gmlwhLI-9cGDbmZkhDafifeJc2VjcDI1NmsxoQJczuIuEAkKdvHogN6dxbIwveUYkCXAm6yuukurgpPSnIhzeW5jbmV0cw-DdGNwgiMog3VkcIIjKA",
+		"nimbus":     "enr:-MK4QBgpjUnYMj6Pb5LP7pwe8dAe4BOQFSyS6KrjGlp0gyugAKAXQFb4dYl_mQOLCgTAo5FGWT7hARPBaOKy2dyDJ0QEh2F0dG5ldHOIAIABAAAAAACDY2djgYCEZXRoMpCBABMacJN1RAABAAAAAAAAgmlkgnY0gmlwhIbHooWJc2VjcDI1NmsxoQM-ZoNHP9Shg_xnnig6etGeMzfC1N0mLiVWCguePKnBTIhzeW5jbmV0cwuDdGNwgiMog3VkcIIjKA",
+		"lodestar":   "enr:-Mq4QF5K5FTqB02r-s-1zPyYrZA7FijHYCbo85mZroTpe21aKv7rsvkGdcZ5mLf08mFQEj_HKpP9_FOOfJwkOpjihSgIh2F0dG5ldHOIDAAAAAAAAACDY2djCIRldGgykIEAExpwk3VEAAEAAAAAAACCaWSCdjSCaXCEiztN34NuZmSENp-J94lzZWNwMjU2azGhA3d-BAO9NxwoQ7qg5jCUZb-MBb91LNYlO8eaoLU3shP4iHN5bmNuZXRzD4N0Y3CCIyiDdWRwgiMo",
+		"grandine":   "enr:-PG4QOcDgNnDfDDOhNcpxWxtlUUu7HyT0KOX4XWnqIwEmBJ-Ek_yVoknbtVGuGVi0HLSONGizfUsiPXi9981Z-ZOu_sJh2F0dG5ldHOIAAMAAAAAAACDY2djCIZjbGllbnTXiEdyYW5kaW5ljTEuMS4xLTU1OTIzYjmEZXRoMpCBABMacJN1RAABAAAAAAAAgmlkgnY0gmlwhC5llUaDbmZkhDafifeEcXVpY4IjKYlzZWNwMjU2azGhA11dnrjCPJFjsyHhXRrgV7wJodrGFgiSGb4GCLWy8UkRiHN5bmNuZXRzD4N0Y3CCIyiDdWRwgiMo",
+	}
+
+	for client, enr := range clients {
+		client := client
+		enr := enr
+		t.Run(fmt.Sprintf("client=%s", client), func(t *testing.T) {
+			testCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			guardian := genBasicGuardian(t, testCtx)
+
+			ethNode, err := ParseNode(enr)
+			require.NoError(t, err, "enr parsing failed for client %s", client)
+
+			_, err = guardian.Scan(testCtx, ethNode)
+			require.NoError(t, err, "interop test failed for client %s", client)
+		})
+	}
+}
+
+// genBasicGuardian initializes a test guardian instance.
+func genBasicGuardian(t *testing.T, ctx context.Context) *DasGuardian {
+	cfg := &DasGuardianConfig{
+		Libp2pHost:        "127.0.0.1",
+		Libp2pPort:        9020,
+		ConnectionRetries: 2,
+		ConnectionTimeout: 30 * time.Second,
+		BeaconAPIendpoint: testBeaconAPI,
+		WaitForFulu:       true,
+	}
+
+	guardian, err := NewDASGuardian(ctx, cfg)
+	require.NoError(t, err)
+	return guardian
+}

--- a/justfile
+++ b/justfile
@@ -9,6 +9,9 @@ install:
 build:
     {{ GOCC }} build -o {{ BUILD_PATH }}/{{ BIN }} {{ TARGET }}
 
+docker:
+	docker build -t probe-lab/das-guardian:latest .
+
 lint:
     staticcheck ./...
 

--- a/rpc_service.go
+++ b/rpc_service.go
@@ -12,7 +12,6 @@ import (
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/encoder"
 	p2ptypes "github.com/OffchainLabs/prysm/v6/beacon-chain/p2p/types"
 	"github.com/OffchainLabs/prysm/v6/consensus-types/primitives"
-	pb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/protocol"
@@ -27,10 +26,6 @@ type ReqRespConfig struct {
 	Encoder      encoder.NetworkEncoding
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
-
-	// local metadata
-	BeaconStatus   pb.StatusV2
-	BeaconMetadata pb.MetaDataV2
 }
 
 // ReqResp implements the request response domain of the eth2 RPC spec:

--- a/rpcs.go
+++ b/rpcs.go
@@ -82,6 +82,9 @@ func (r *ReqResp) GoodBye(ctx context.Context, pid peer.ID) (err error) {
 }
 
 func (r *ReqResp) StatusV1(ctx context.Context, pid peer.ID, st *pb.Status) (status *pb.Status, err error) {
+	if isNill(st) {
+		return nil, fmt.Errorf("the given local-status-v1 is a nil pointer")
+	}
 	if err := r.EnsureConnectionToPeer(ctx, pid); err != nil {
 		return nil, err
 	}
@@ -108,6 +111,9 @@ func (r *ReqResp) StatusV1(ctx context.Context, pid peer.ID, st *pb.Status) (sta
 }
 
 func (r *ReqResp) StatusV2(ctx context.Context, pid peer.ID, st *pb.StatusV2) (status *pb.StatusV2, err error) {
+	if isNill(st) {
+		return nil, fmt.Errorf("the given local-status-v2 is a nil pointer")
+	}
 	if err := r.EnsureConnectionToPeer(ctx, pid); err != nil {
 		return nil, errors.Wrap(err, "connection wasn't stablished when requesting status-v2")
 	}
@@ -118,13 +124,13 @@ func (r *ReqResp) StatusV2(ctx context.Context, pid peer.ID, st *pb.StatusV2) (s
 	defer stream.Reset()
 
 	if err := r.writeRequest(ctx, stream, st); err != nil {
-		return nil, fmt.Errorf("write status request: %w", err)
+		return nil, fmt.Errorf("write status-v2 request: %w", err)
 	}
 
 	// read and decode status response
 	resp := &pb.StatusV2{}
 	if err := r.readResponse(ctx, stream, resp); err != nil {
-		return nil, fmt.Errorf("read status response: %w", err)
+		return nil, fmt.Errorf("read status-v2 response: %w", err)
 	}
 
 	// we have the data that we want, so ignore error here
@@ -134,6 +140,9 @@ func (r *ReqResp) StatusV2(ctx context.Context, pid peer.ID, st *pb.StatusV2) (s
 }
 
 func (r *ReqResp) MetaDataV2(ctx context.Context, pid peer.ID, mt *pb.MetaDataV1) (resp *pb.MetaDataV1, err error) {
+	if isNill(mt) {
+		return nil, fmt.Errorf("the given local-metadata-v2 is a nil pointer")
+	}
 	if err := r.EnsureConnectionToPeer(ctx, pid); err != nil {
 		return nil, err
 	}
@@ -144,13 +153,13 @@ func (r *ReqResp) MetaDataV2(ctx context.Context, pid peer.ID, mt *pb.MetaDataV1
 	defer stream.Reset()
 
 	if err := r.writeRequest(ctx, stream, mt); err != nil {
-		return nil, fmt.Errorf("write status request: %w", err)
+		return nil, fmt.Errorf("write metadata-v2 request: %w", err)
 	}
 
 	// read and decode status response
 	resp = &pb.MetaDataV1{}
 	if err := r.readResponse(ctx, stream, resp); err != nil {
-		return nil, fmt.Errorf("read metadata response: %w", err)
+		return nil, fmt.Errorf("read metadata-v2 response: %w", err)
 	}
 
 	// we have the data that we want, so ignore error here
@@ -160,6 +169,10 @@ func (r *ReqResp) MetaDataV2(ctx context.Context, pid peer.ID, mt *pb.MetaDataV1
 }
 
 func (r *ReqResp) MetaDataV3(ctx context.Context, pid peer.ID, mt *pb.MetaDataV2) (resp *pb.MetaDataV2, err error) {
+	fmt.Println(mt)
+	if isNill(mt) {
+		return nil, fmt.Errorf("the given local-metadata-v3 is a nil pointer")
+	}
 	if err := r.EnsureConnectionToPeer(ctx, pid); err != nil {
 		return nil, err
 	}
@@ -170,13 +183,13 @@ func (r *ReqResp) MetaDataV3(ctx context.Context, pid peer.ID, mt *pb.MetaDataV2
 	defer stream.Reset()
 
 	if err := r.writeRequest(ctx, stream, mt); err != nil {
-		return nil, fmt.Errorf("write status request: %w", err)
+		return nil, fmt.Errorf("write metadata-v3 request: %w", err)
 	}
 
 	// read and decode status response
 	resp = &pb.MetaDataV2{}
 	if err := r.readResponse(ctx, stream, resp); err != nil {
-		return nil, fmt.Errorf("read metadata response: %w", err)
+		return nil, fmt.Errorf("read metadata-v3 response: %w", err)
 	}
 
 	// we have the data that we want, so ignore error here

--- a/utils.go
+++ b/utils.go
@@ -65,3 +65,7 @@ func truncateStr(text string, width int) string {
 	trunc := r[:width]
 	return string(trunc) + "..."
 }
+
+func isNill(i any) bool {
+	return i == nil
+}


### PR DESCRIPTION
# Description
Following the feedback and suggestions from @barnabasbusa , this PR enables the forever monitoring of nodes for both electra and fulu states.

WIP, there are still a few items that need to be updated/tested:
- [x] the state transition from electra to fulu
- [ ] the correct computation of the fulu (BPO supporting) fork digest calculation (WIP)
- [x] some RPCs are failing (MetadataV3 for some nodes)
- [ ] I couldn't test any electra state (yet)