### PR TITLE
beacon api interface & fork digest fix

### DIFF
--- a/api/config_specs.go
+++ b/api/config_specs.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/pkg/errors"
+)
+
+var ConfigSpecBase = "eth/v1/config/spec"
+
+func (c *Client) GetConfigSpecs(ctx context.Context) (map[string]any, error) {
+	var configSpecs map[string]any
+	resp, err := c.get(ctx, c.cfg.QueryTimeout, ConfigSpecBase, "")
+	if err != nil {
+		return nil, errors.Wrap(err, "requesting config-specs")
+	}
+	err = json.Unmarshal(resp, &configSpecs)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshaling config-specs from http request")
+	}
+
+	return parseSpecMap(configSpecs["data"].(map[string]any)), nil
+}
+
+func parseSpecMap(data map[string]any) map[string]any {
+	config := make(map[string]any)
+	for k, v := range data {
+		switch value := v.(type) {
+		case string:
+			config[k] = parseSpecString(k, value)
+		case []any:
+			config[k] = parseSpecArray(value)
+		case map[string]any:
+			config[k] = parseSpecMap(value)
+		default:
+			config[k] = v
+		}
+	}
+
+	return config
+}
+
+func parseSpecArray(array []any) []any {
+	result := make([]any, len(array))
+	for i, element := range array {
+		switch value := element.(type) {
+		case string:
+			result[i] = parseSpecString("", value)
+		case []any:
+			result[i] = parseSpecArray(value)
+		case map[string]any:
+			result[i] = parseSpecMap(value)
+		default:
+			result[i] = element
+		}
+	}
+
+	return result
+}
+
+func parseSpecString(k, v string) any {
+	// Handle domains.
+	if strings.HasPrefix(k, "DOMAIN_") {
+		byteVal, err := hex.DecodeString(strings.TrimPrefix(v, "0x"))
+		if err == nil {
+			var domainType phase0.DomainType
+			copy(domainType[:], byteVal)
+
+			return domainType
+		}
+	}
+
+	// Handle fork versions.
+	if strings.HasSuffix(k, "_FORK_VERSION") {
+		byteVal, err := hex.DecodeString(strings.TrimPrefix(v, "0x"))
+		if err == nil {
+			var version phase0.Version
+			copy(version[:], byteVal)
+
+			return version
+		}
+	}
+
+	// Handle hex strings.
+	if strings.HasPrefix(v, "0x") {
+		byteVal, err := hex.DecodeString(strings.TrimPrefix(v, "0x"))
+		if err == nil {
+			return byteVal
+		}
+	}
+
+	// Handle times.
+	if strings.HasSuffix(k, "_TIME") {
+		intVal, err := strconv.ParseInt(v, 10, 64)
+		if err == nil && intVal != 0 {
+			return time.Unix(intVal, 0)
+		}
+	}
+
+	// Handle durations.
+	if strings.HasPrefix(k, "SECONDS_PER_") || k == "GENESIS_DELAY" {
+		intVal, err := strconv.ParseInt(v, 10, 64)
+		if err == nil && intVal >= 0 {
+			return time.Duration(intVal) * time.Second
+		}
+	}
+
+	// Handle integers.
+	if v == "0" {
+		return uint64(0)
+	}
+	intVal, err := strconv.ParseUint(v, 10, 64)
+	if err == nil && intVal != 0 {
+		return intVal
+	}
+
+	// Assume string.
+	return v
+}

--- a/api/node_identity.go
+++ b/api/node_identity.go
@@ -37,15 +37,15 @@ func (i *NodeIdentity) Syncnets() string {
 	return i.Data.Metadata.Syncnets
 }
 
-func (c *Client) GetNodeIdentity(ctx context.Context) (NodeIdentity, error) {
+func (c *Client) GetNodeIdentity(ctx context.Context) (*NodeIdentity, error) {
 	var nodeIdentity NodeIdentity
 	resp, err := c.get(ctx, c.cfg.QueryTimeout, NodeIdentityBase, "")
 	if err != nil {
-		return nodeIdentity, errors.Wrap(err, "requesting node-identity")
+		return nil, errors.Wrap(err, "requesting node-identity")
 	}
 	err = json.Unmarshal(resp, &nodeIdentity)
 	if err != nil {
-		return nodeIdentity, errors.Wrap(err, "unmarshaling node-identity from http request")
+		return nil, errors.Wrap(err, "unmarshaling node-identity from http request")
 	}
-	return nodeIdentity, nil
+	return &nodeIdentity, nil
 }

--- a/beacon_api.go
+++ b/beacon_api.go
@@ -1,0 +1,156 @@
+package dasguardian
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/probe-lab/eth-das-guardian/api"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	ApiStateTimeout     = 30 * time.Second
+	ApiQueryTimeout     = 10 * time.Second
+	FuluSupportRetry    = 12 * time.Second // 1 slot
+	FuluForkScheduleIdx = 6                //  Fulu is the 7th fork -> index = 6
+)
+
+type BeaconAPI interface {
+	Init(ctx context.Context) error
+	GetForkDigest() ([]byte, error)
+	GetFinalizedCheckpoint() *phase0.Checkpoint
+	GetLatestBlockHeader() *phase0.BeaconBlockHeader
+	GetFuluForkEpoch() int
+	GetNodeIdentity(ctx context.Context) (*api.NodeIdentity, error)
+	GetBeaconBlock(ctx context.Context, slot uint64) (*spec.VersionedSignedBeaconBlock, error)
+}
+
+type BeaconAPIConfig struct {
+	Logger      log.FieldLogger
+	Endpoint    string
+	WaitForFulu bool
+}
+
+type BeaconAPIImpl struct {
+	cfg    BeaconAPIConfig
+	apiCli *api.Client
+
+	headState     *api.PeerDASstate
+	forkSchedules api.ForkSchedule
+	fuluForkEpoch int
+}
+
+func NewBeaconAPI(cfg BeaconAPIConfig) (BeaconAPI, error) {
+	ethApiCfg := api.ClientConfig{
+		Endpoint:     cfg.Endpoint,
+		StateTimeout: ApiStateTimeout,
+		QueryTimeout: ApiQueryTimeout,
+	}
+	apiCli, err := api.NewClient(ethApiCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BeaconAPIImpl{
+		cfg:    cfg,
+		apiCli: apiCli,
+	}, nil
+}
+
+func (b *BeaconAPIImpl) Init(ctx context.Context) error {
+	// check api connection
+	if err := b.apiCli.CheckConnection(ctx); err != nil {
+		return fmt.Errorf("connection to %s was stablished, but not active - %s", b.cfg.Endpoint, err.Error())
+	}
+	b.cfg.Logger.Info("connected to the beacon API...")
+
+	// get the network configuration from the apiCli
+	forkSchedules, err := b.apiCli.GetNetworkConfig(ctx)
+	if err != nil {
+		return err
+	}
+	b.forkSchedules = forkSchedules.Data[FuluForkScheduleIdx] // we only need the fulu specifics
+
+	// compose and get the local Metadata
+	currentState, err := b.apiCli.GetPeerDASstate(ctx)
+	if err != nil {
+		return err
+	}
+
+	fuluForkEpoch, err := strconv.Atoi(b.forkSchedules.Epoch)
+	if err != nil {
+		return err
+	}
+
+	b.fuluForkEpoch = fuluForkEpoch
+
+	if (int(currentState.Data.Slot) / 32) < fuluForkEpoch {
+		secondsToFulu := time.Duration(((fuluForkEpoch*32)-int(currentState.Data.Slot))*12) * time.Second
+		b.cfg.Logger.Warnf("network doesn't support fulu yet")
+		b.cfg.Logger.Warnf("current: (slot: %d epoch: %d - version: %s)", currentState.Data.Slot, (currentState.Data.Slot / 32), currentState.Version)
+		b.cfg.Logger.Warnf("target:  (slot: %d epoch: %d - missing: %d = %s)", fuluForkEpoch*32, fuluForkEpoch, (fuluForkEpoch*32)-int(currentState.Data.Slot), secondsToFulu)
+		if b.cfg.WaitForFulu {
+			b.cfg.Logger.Info("waiting for ", secondsToFulu)
+			if secondsToFulu < 0 {
+				return fmt.Errorf("neg time to fulu?!")
+			}
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("tooled closed without reaching fulu upgrade")
+
+			case <-time.After(secondsToFulu):
+				currentState, err = b.apiCli.GetPeerDASstate(ctx)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			return fmt.Errorf("network doesn't support fulu yet (slot: %d - %s)", currentState.Data.Slot, currentState.Version)
+		}
+	} else {
+		b.cfg.Logger.Info("fulu is supported")
+		fmt.Sprintln((int(currentState.Data.Slot) / 32), fuluForkEpoch)
+	}
+
+	prettyLogrusFields(b.cfg.Logger, "dowloaded beacon head-state", map[string]any{
+		"version":       currentState.Version,
+		"finalized":     currentState.Finalized,
+		"optimistic-el": currentState.ExecutionOptimistic,
+		"validators":    len(currentState.Data.Validators),
+	})
+
+	b.headState = &currentState
+	return nil
+}
+
+func (b *BeaconAPIImpl) GetForkDigest() ([]byte, error) {
+	forkDigest, err := computeForkDigest(
+		b.headState.Data.Fork.CurrentVersion[:],
+		b.headState.Data.GenesisValidatorsRoot[:],
+	)
+	return forkDigest, err
+}
+
+func (b *BeaconAPIImpl) GetFinalizedCheckpoint() *phase0.Checkpoint {
+	return b.headState.Data.FinalizedCheckpoint
+}
+
+func (b *BeaconAPIImpl) GetLatestBlockHeader() *phase0.BeaconBlockHeader {
+	return b.headState.Data.LatestBlockHeader
+}
+
+func (b *BeaconAPIImpl) GetFuluForkEpoch() int {
+	return b.fuluForkEpoch
+}
+
+func (b *BeaconAPIImpl) GetNodeIdentity(ctx context.Context) (*api.NodeIdentity, error) {
+	return b.apiCli.GetNodeIdentity(ctx)
+}
+
+func (b *BeaconAPIImpl) GetBeaconBlock(ctx context.Context, slot uint64) (*spec.VersionedSignedBeaconBlock, error) {
+	return b.apiCli.GetBeaconBlock(ctx, slot)
+}

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -41,12 +41,14 @@ var monitorFlags = []cli.Flag{
 }
 
 func monitorAction(ctx context.Context, cmd *cli.Command) error {
-	log.WithFields(log.Fields{
+	logger := log.WithFields(log.Fields{})
+	logger.WithFields(log.Fields{
 		"freq":     monitorConfig.MonitorFrequency,
 		"duration": monitorConfig.MonitorDuration,
 	}).Info("monitor cmd...")
 
 	ethConfig := &dasguardian.DasGuardianConfig{
+		Logger:            logger,
 		Libp2pHost:        rootConfig.Libp2pHost,
 		Libp2pPort:        rootConfig.Libp2pPort,
 		ConnectionRetries: rootConfig.ConnectionRetries,

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -42,7 +42,10 @@ var scanFlags = []cli.Flag{
 }
 
 func scanAction(ctx context.Context, cmd *cli.Command) error {
+	logger := log.WithFields(log.Fields{})
+
 	ethConfig := &dasguardian.DasGuardianConfig{
+		Logger:            logger,
 		Libp2pHost:        rootConfig.Libp2pHost,
 		Libp2pPort:        rootConfig.Libp2pPort,
 		ConnectionRetries: rootConfig.ConnectionRetries,
@@ -73,7 +76,7 @@ func scanAction(ctx context.Context, cmd *cli.Command) error {
 		if err != nil {
 			return err
 		}
-		return res.LogVisualization()
+		return res.LogVisualization(logger)
 
 	default:
 		ethNodes := make([]*enode.Node, len(scanConfig.NodeKeys))
@@ -95,7 +98,7 @@ func scanAction(ctx context.Context, cmd *cli.Command) error {
 		}
 		// TODO: hardcoded visualization
 		for _, r := range res {
-			err = r.LogVisualization()
+			err = r.LogVisualization(logger)
 			if err != nil {
 				log.Error(err)
 			}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -76,7 +76,7 @@ func scanAction(ctx context.Context, cmd *cli.Command) error {
 		if err != nil {
 			return err
 		}
-		return res.LogVisualization(logger)
+		return res.EvalResult.LogVisualization(logger)
 
 	default:
 		ethNodes := make([]*enode.Node, len(scanConfig.NodeKeys))
@@ -98,7 +98,7 @@ func scanAction(ctx context.Context, cmd *cli.Command) error {
 		}
 		// TODO: hardcoded visualization
 		for _, r := range res {
-			err = r.LogVisualization(logger)
+			err = r.EvalResult.LogVisualization(logger)
 			if err != nil {
 				log.Error(err)
 			}

--- a/guardian_utils.go
+++ b/guardian_utils.go
@@ -21,10 +21,10 @@ func computeForkDigest(forkV []byte, valRoots []byte) ([]byte, error) {
 	return digest[:], nil
 }
 
-func prettyLogrusFields(msg string, fields map[string]any) {
-	log.Info(msg)
+func prettyLogrusFields(logger log.FieldLogger, msg string, fields map[string]any) {
+	logger.Info(msg)
 	for k, v := range fields {
-		log.Info("\t* ", k, ":\t", v)
+		logger.Info("\t* ", k, ":\t", v)
 	}
 }
 

--- a/guardian_utils.go
+++ b/guardian_utils.go
@@ -4,22 +4,8 @@ import (
 	"fmt"
 	mrand "math/rand"
 
-	"github.com/OffchainLabs/prysm/v6/encoding/bytesutil"
-	pb "github.com/OffchainLabs/prysm/v6/proto/prysm/v1alpha1"
 	log "github.com/sirupsen/logrus"
 )
-
-func computeForkDigest(forkV []byte, valRoots []byte) ([]byte, error) {
-	r, err := (&pb.ForkData{
-		CurrentVersion:        forkV,
-		GenesisValidatorsRoot: valRoots,
-	}).HashTreeRoot()
-	if err != nil {
-		return []byte{}, err
-	}
-	digest := bytesutil.ToBytes4(r[:])
-	return digest[:], nil
-}
 
 func prettyLogrusFields(logger log.FieldLogger, msg string, fields map[string]any) {
 	logger.Info(msg)

--- a/rpc_service.go
+++ b/rpc_service.go
@@ -24,13 +24,14 @@ var (
 )
 
 type ReqRespConfig struct {
+	Logger       log.FieldLogger
 	Encoder      encoder.NetworkEncoding
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
 
 	// local metadata
-	BeaconStatus   pb.StatusV2
-	BeaconMetadata pb.MetaDataV2
+	BeaconStatus   *pb.StatusV2
+	BeaconMetadata *pb.MetaDataV2
 }
 
 // ReqResp implements the request response domain of the eth2 RPC spec:

--- a/rpc_service.go
+++ b/rpc_service.go
@@ -76,7 +76,7 @@ func (r *ReqResp) RegisterHandlers(ctx context.Context) error {
 
 	for id, handler := range handlers {
 		protocolID := r.protocolID(id)
-		log.WithField("protocol", protocolID).Debug("Register protocol handler...")
+		r.cfg.Logger.WithField("protocol", protocolID).Debug("Register protocol handler...")
 		r.host.SetStreamHandler(protocolID, r.wrapStreamHandler(ctx, string(protocolID), handler))
 	}
 
@@ -183,7 +183,7 @@ func (r *ReqResp) wrapStreamHandler(ctx context.Context, name string, handler Co
 		// time the request handling
 		err := handler(ctx, s)
 		if err != nil {
-			log.WithFields(log.Fields{
+			r.cfg.Logger.WithFields(log.Fields{
 				"protocol":    s.Protocol(),
 				"error":       err,
 				"remote-peer": s.Conn().RemotePeer().String(),
@@ -200,7 +200,7 @@ func (r *ReqResp) pingHandler(ctx context.Context, stream network.Stream) error 
 
 	sq := primitives.SSZUint64(uint64(23))
 	if err := r.writeResponse(ctx, stream, &sq); err != nil {
-		log.Error("write sequence number", err)
+		r.cfg.Logger.Error("write sequence number", err)
 	}
 	return stream.Close()
 }
@@ -211,7 +211,7 @@ func (r *ReqResp) goodbyeHandler(ctx context.Context, stream network.Stream) err
 		return fmt.Errorf("read sequence number: %w", err)
 	}
 	reason := ParseGoodByeReason(req)
-	log.WithFields(log.Fields{
+	r.cfg.Logger.WithFields(log.Fields{
 		"peer_id":  stream.Conn().RemotePeer().String(),
 		"err_code": req,
 		"reason":   reason,

--- a/rpcs.go
+++ b/rpcs.go
@@ -91,7 +91,7 @@ func (r *ReqResp) StatusV1(ctx context.Context, pid peer.ID) (status *pb.Status,
 	}
 	defer stream.Reset()
 
-	if err := r.writeRequest(ctx, stream, &r.cfg.BeaconStatus); err != nil {
+	if err := r.writeRequest(ctx, stream, r.cfg.BeaconStatus); err != nil {
 		return nil, fmt.Errorf("write status request: %w", err)
 	}
 
@@ -117,7 +117,7 @@ func (r *ReqResp) StatusV2(ctx context.Context, pid peer.ID) (status *pb.StatusV
 	}
 	defer stream.Reset()
 
-	if err := r.writeRequest(ctx, stream, &r.cfg.BeaconStatus); err != nil {
+	if err := r.writeRequest(ctx, stream, r.cfg.BeaconStatus); err != nil {
 		return nil, fmt.Errorf("write status request: %w", err)
 	}
 
@@ -143,7 +143,7 @@ func (r *ReqResp) MetaDataV3(ctx context.Context, pid peer.ID) (resp *pb.MetaDat
 	}
 	defer stream.Reset()
 
-	if err := r.writeRequest(ctx, stream, &r.cfg.BeaconMetadata); err != nil {
+	if err := r.writeRequest(ctx, stream, r.cfg.BeaconMetadata); err != nil {
 		return nil, fmt.Errorf("write status request: %w", err)
 	}
 

--- a/topics.go
+++ b/topics.go
@@ -1,26 +1,13 @@
 package dasguardian
 
 import (
-	"context"
 	"fmt"
-
-	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
-var GossipBeaconBlock = "/eth/%s/beacon_block/ssz_snappy"
+var GossipBeaconBlock = "/eth/%x/beacon_block/ssz_snappy"
 
-func getMandatoryTopics(forkD string) []string {
+func getMandatoryTopics(forkDigest []byte) []string {
 	return []string{
-		fmt.Sprintf(GossipBeaconBlock, forkD),
+		fmt.Sprintf(GossipBeaconBlock, forkDigest),
 	}
-}
-
-//lint:ignore U1000 ignore this, keeping it just in case!
-func dummyHandler(ctx context.Context, msg *pubsub.Message) error {
-	prettyLogrusFields("new message", map[string]any{
-		"topic": msg.Topic,
-		"from":  string(msg.From),
-		"bytes": len(msg.Data),
-	})
-	return nil
 }


### PR DESCRIPTION
Heya @cortze,

This PR reorganizes the beacon api accessors behind a interface. 
This allows separate beacon api implementation, where state & metadata requests are redundant and can be served from memory.
I've used this to add this tool to dora: https://github.com/ethpandaops/dora/pull/427
When using the CLI, the default implementation of that interface still calls the beacon api as usual.

I hope the additional complexity of having the beacon api behind a interface is acceptable?

I've also fixes the fork digest calculation. According to a recent spec change, the fork digest now changes with BPOs, so we need to load the specs and check which BPO is active to calculate the correct fork digest.

