### PR TITLE
fix: digest calculation with bpo

### DIFF
--- a/beacon_api.go
+++ b/beacon_api.go
@@ -203,7 +203,7 @@ func (b *BeaconAPIImpl) GetForkDigest(slot uint64) ([]byte, error) {
 			maxBlobsPerBlockElectra = 0
 		}
 
-		currentBlobParams := BlobScheduleEntry{
+		currentBlobParams = &BlobScheduleEntry{
 			Epoch:            b.specs["ELECTRA_FORK_EPOCH"].(uint64),
 			MaxBlobsPerBlock: maxBlobsPerBlockElectra,
 		}


### PR DESCRIPTION
Fixing: 
```
WARN[0060] received GoodBye from 16Uiu2HAm9wVszm4bpyqFxXuwENuBCtD7bCapYaHEX9BGXLnT3DMr  err_code=2 peer_id=16Uiu2HAm9wVszm4bpyqFxXuwENuBCtD7bCapYaHEX9BGXLnT3DMr reason="irrelevant network"
```

The remote peer 16Uiu2HAm9wVszm4bpyqFxXuwENuBCtD7bCapYaHEX9BGXLnT3DMr has fork digest `0xf05090da` while
guardian was calculating `0x97971f06`.

The bug was: The code was creating a local variable currentBlobParams instead of assigning to the outer scope variable. By changing:
```go
  currentBlobParams := BlobScheduleEntry{  // local variable, doesn't affect the outer scope
```
  To:
```go
  currentBlobParams = &BlobScheduleEntry{  // assigns to the outer scope variable
```