### PR TITLE
feat: add peerid log on startup

### DIFF
--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -63,5 +63,10 @@ func monitorAction(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
+
+	log.WithFields(log.Fields{
+		"peer-id": guardian.Host().ID().String(),
+	}).Info("das-guardian initialized")
+
 	return guardian.MonitorEndpoint(ctx)
 }

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -70,6 +70,10 @@ func scanAction(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
+	log.WithFields(log.Fields{
+		"peer-id": guardian.Host().ID().String(),
+	}).Info("das-guardian initialized")
+
 	switch len(scanConfig.NodeKeys) {
 	case 0:
 		return errors.New("no ENR keys were given")

--- a/guardian.go
+++ b/guardian.go
@@ -195,6 +195,10 @@ func NewDASGuardian(ctx context.Context, cfg *DasGuardianConfig) (*DasGuardian, 
 	return guardian, nil
 }
 
+func (g *DasGuardian) Host() host.Host {
+	return g.host
+}
+
 func (g *DasGuardian) init(ctx context.Context) error {
 	// init beacon-api
 	if err := g.apiCli.Init(ctx); err != nil {


### PR DESCRIPTION
example: 
```
time="2025-07-14T09:45:44Z" level=info msg="das-guardian initialized" peer-id=16Uiu2HAkxGVyKk6Tekzn171dgcqSuporSbKbgocjDRtcHhNtUcNk
```
