### PR TITLE
refactor(rpcs): stream closing + connection to peer logic

### DIFF
--- a/beacon_api.go
+++ b/beacon_api.go
@@ -283,7 +283,7 @@ func (b *BeaconAPIImpl) GetForkDigest(slot uint64) ([]byte, error) {
 		blobSchedule, ok := b.specs["BLOB_SCHEDULE"].([]any)
 		if !ok {
 			// BLOB_SCHEDULE is not present - this happens when no BPO (Blob Parameter Override) is scheduled.
-			b.cfg.Logger.Warn("BLOB_SCHEDULE not found, if one is expected, this will cause this will cause network incompatibility")
+			b.cfg.Logger.Warn("BLOB_SCHEDULE not found, if one is expected, this will cause network incompatibility")
 		}
 
 		type blobParam struct {

--- a/beacon_api.go
+++ b/beacon_api.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"time"
 
@@ -281,22 +282,36 @@ func (b *BeaconAPIImpl) GetForkDigest(slot uint64) ([]byte, error) {
 
 		blobSchedule, ok := b.specs["BLOB_SCHEDULE"].([]any)
 		if !ok {
-			// BLOB_SCHEDULE is not present - this happens when no BPO (Blob Parameter Override) is scheduled
-			b.cfg.Logger.Info("BLOB_SCHEDULE not found (no BPO scheduled), skipping blob parameter computation")
+			// BLOB_SCHEDULE is not present - this happens when no BPO (Blob Parameter Override) is scheduled.
+			b.cfg.Logger.Warn("BLOB_SCHEDULE not found, if one is expected, this will cause this will cause network incompatibility")
 		}
+
+		type blobParam struct {
+			Epoch            uint64
+			MaxBlobsPerBlock uint64
+		}
+
+		var parsedSchedule []blobParam
 
 		for _, blobScheduleEntry := range blobSchedule {
 			blobScheduleMap := blobScheduleEntry.(map[string]any)
-			epoch, ok := blobScheduleMap["EPOCH"].(uint64)
-			if !ok {
-				continue
-			}
+			epoch := blobScheduleMap["EPOCH"].(uint64)
+			maxBlobs := blobScheduleMap["MAX_BLOBS_PER_BLOCK"].(uint64)
 
-			if epoch <= currentEpoch {
-				currentBlobParams.Epoch = epoch
-				currentBlobParams.MaxBlobsPerBlock = blobScheduleMap["MAX_BLOBS_PER_BLOCK"].(uint64)
-			} else {
-				break
+			parsedSchedule = append(parsedSchedule, blobParam{
+				Epoch:            epoch,
+				MaxBlobsPerBlock: maxBlobs,
+			})
+		}
+
+		sort.Slice(parsedSchedule, func(i, j int) bool {
+			return parsedSchedule[i].Epoch < parsedSchedule[j].Epoch
+		})
+
+		for _, param := range parsedSchedule {
+			if param.Epoch <= currentEpoch {
+				currentBlobParams.Epoch = param.Epoch
+				currentBlobParams.MaxBlobsPerBlock = param.MaxBlobsPerBlock
 			}
 		}
 	}

--- a/rpcs.go
+++ b/rpcs.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
-	log "github.com/sirupsen/logrus"
 )
 
 const PeerDAScolumns = 128
@@ -20,10 +20,9 @@ const PeerDAScolumns = 128
 func (r *ReqResp) EnsureConnectionToPeer(ctx context.Context, pid peer.ID) error {
 	constatus := r.host.Network().Connectedness(pid)
 	if constatus != network.Connected {
-		return nil
-	} else {
 		return r.host.Connect(ctx, r.host.Peerstore().PeerInfo(pid))
 	}
+	return nil
 }
 
 func (r *ReqResp) Ping(ctx context.Context, pid peer.ID) (err error) {
@@ -34,21 +33,22 @@ func (r *ReqResp) Ping(ctx context.Context, pid peer.ID) (err error) {
 	if err != nil {
 		return fmt.Errorf("new %s stream to peer %s: %w", RPCPingTopicV1, pid, err)
 	}
-	defer stream.Reset()
 
 	req := uint64(1)
 	if err := r.writeRequest(stream, &req); err != nil {
+		stream.Reset()
 		return fmt.Errorf("write ping request: %w", err)
 	}
 
-	// read and decode status response
+	// read and decode ping response
 	resp := uint64(0)
 	if err := r.readResponse(stream, &resp); err != nil {
+		stream.Reset()
 		return fmt.Errorf("read ping response: %w", err)
 	}
 
-	// we have the data that we want, so ignore error here
-	_ = stream.Close() // (both sides should actually be already closed)
+	// we have the data that we want, close stream cleanly
+	_ = stream.Close()
 
 	return nil
 }
@@ -58,21 +58,22 @@ func (r *ReqResp) GoodBye(ctx context.Context, pid peer.ID) (err error) {
 	if err != nil {
 		return fmt.Errorf("new %s stream to peer %s: %w", RPCGoodByeTopicV1, pid, err)
 	}
-	defer stream.Reset()
 
 	req := uint64(1)
 	if err := r.writeRequest(stream, &req); err != nil {
+		stream.Reset()
 		return fmt.Errorf("write goodbye request: %w", err)
 	}
 
-	// read and decode status response
+	// read and decode goodbye response
 	resp := uint64(0)
-	if err := r.readResponse(stream, resp); err != nil {
+	if err := r.readResponse(stream, &resp); err != nil {
+		stream.Reset()
 		return fmt.Errorf("read goodbye response: %w", err)
 	}
 
-	// we have the data that we want, so ignore error here
-	_ = stream.Close() // (both sides should actually be already closed)
+	// we have the data that we want, close stream cleanly
+	_ = stream.Close()
 
 	return nil
 }
@@ -88,20 +89,21 @@ func (r *ReqResp) StatusV1(ctx context.Context, pid peer.ID, st *StatusV1) (stat
 	if err != nil {
 		return nil, fmt.Errorf("new stream to peer %s: %w", pid, err)
 	}
-	defer stream.Reset()
 
 	if err := r.writeRequest(stream, st); err != nil {
+		stream.Reset()
 		return nil, fmt.Errorf("write status-v1 request: %w", err)
 	}
 
 	// read and decode status response
 	resp := &StatusV1{}
 	if err := r.readResponse(stream, resp); err != nil {
+		stream.Reset()
 		return nil, fmt.Errorf("read status-v1 response: %w", err)
 	}
 
-	// we have the data that we want, so ignore error here
-	_ = stream.Close() // (both sides should actually be already closed)
+	// we have the data that we want, close stream cleanly
+	_ = stream.Close()
 
 	return resp, nil
 }
@@ -117,20 +119,21 @@ func (r *ReqResp) StatusV2(ctx context.Context, pid peer.ID, st *StatusV2) (stat
 	if err != nil {
 		return nil, fmt.Errorf("new stream to peer %s: %w", pid, err)
 	}
-	defer stream.Reset()
 
 	if err := r.writeRequest(stream, st); err != nil {
+		stream.Reset()
 		return nil, fmt.Errorf("write status-v2 request: %w", err)
 	}
 
 	// read and decode status response
 	resp := &StatusV2{}
 	if err := r.readResponse(stream, resp); err != nil {
+		stream.Reset()
 		return nil, fmt.Errorf("read status-v2 response: %w", err)
 	}
 
-	// we have the data that we want, so ignore error here
-	_ = stream.Close() // (both sides should actually be already closed)
+	// we have the data that we want, close stream cleanly
+	_ = stream.Close()
 
 	return resp, nil
 }
@@ -146,20 +149,21 @@ func (r *ReqResp) MetaDataV2(ctx context.Context, pid peer.ID, md *MetaDataV2) (
 	if err != nil {
 		return resp, fmt.Errorf("new %s stream to peer %s: %w", RPCMetaDataTopicV2, pid, err)
 	}
-	defer stream.Reset()
 
 	if err := r.writeRequest(stream, md); err != nil {
+		stream.Reset()
 		return nil, fmt.Errorf("write metadata-v2 request: %w", err)
 	}
 
-	// read and decode status response
+	// read and decode metadata response
 	resp = &MetaDataV2{}
 	if err := r.readResponse(stream, resp); err != nil {
+		stream.Reset()
 		return nil, fmt.Errorf("read metadata-v2 response: %w", err)
 	}
 
-	// we have the data that we want, so ignore error here
-	_ = stream.Close() // (both sides should actually be already closed)
+	// we have the data that we want, close stream cleanly
+	_ = stream.Close()
 
 	return resp, nil
 }
@@ -196,7 +200,6 @@ func (r *ReqResp) MetaDataV3(ctx context.Context, pid peer.ID, md *MetaDataV3) (
 		}
 		return resp, fmt.Errorf("new %s stream to peer %s: %w", RPCMetaDataTopicV3, pid, err)
 	}
-	defer stream.Reset()
 
 	if log.GetLevel() >= log.DebugLevel {
 		r.cfg.Logger.WithFields(log.Fields{
@@ -209,6 +212,7 @@ func (r *ReqResp) MetaDataV3(ctx context.Context, pid peer.ID, md *MetaDataV3) (
 	}
 
 	if err := r.writeRequest(stream, md); err != nil {
+		stream.Reset()
 		if log.GetLevel() >= log.DebugLevel {
 			r.cfg.Logger.WithFields(log.Fields{
 				"peer_id": pid.String(),
@@ -224,9 +228,10 @@ func (r *ReqResp) MetaDataV3(ctx context.Context, pid peer.ID, md *MetaDataV3) (
 		}).Debug("MetaDataV3 request written, reading response")
 	}
 
-	// read and decode status response with detailed logging
+	// read and decode metadata response with detailed logging
 	resp = &MetaDataV3{}
 	if err := r.readResponse(stream, resp); err != nil {
+		stream.Reset()
 		if log.GetLevel() >= log.DebugLevel {
 			r.cfg.Logger.WithFields(log.Fields{
 				"peer_id": pid.String(),
@@ -246,8 +251,8 @@ func (r *ReqResp) MetaDataV3(ctx context.Context, pid peer.ID, md *MetaDataV3) (
 		}).Debug("Successfully received MetaDataV3 response with full payload")
 	}
 
-	// we have the data that we want, so ignore error here
-	_ = stream.Close() // (both sides should actually be already closed)
+	// we have the data that we want, close stream cleanly
+	_ = stream.Close()
 
 	return resp, nil
 }
@@ -264,8 +269,6 @@ func (r *ReqResp) RawBlocksByRangeV2(ctx context.Context, pid peer.ID, startSlot
 	if err != nil {
 		return blocks, fmt.Errorf("new %s stream to peer %s: %w", RPCMetaDataTopicV2, pid, err)
 	}
-	defer stream.Close()
-	defer stream.Reset()
 
 	req := &BeaconBlocksByRangeRequestV1{
 		StartSlot: uint64(startSlot),
@@ -273,10 +276,11 @@ func (r *ReqResp) RawBlocksByRangeV2(ctx context.Context, pid peer.ID, startSlot
 		Step:      1,
 	}
 	if err := r.writeRequest(stream, req); err != nil {
+		stream.Reset()
 		return blocks, fmt.Errorf("write block_by_range request: %w", err)
 	}
 
-	// read and decode status response
+	// read and decode block responses
 	for i := uint64(0); ; i++ {
 		isFirstChunk := i == 0
 		block := &deneb.SignedBeaconBlock{}
@@ -285,10 +289,14 @@ func (r *ReqResp) RawBlocksByRangeV2(ctx context.Context, pid peer.ID, startSlot
 			break
 		}
 		if err != nil {
+			stream.Reset()
 			return nil, fmt.Errorf("reading block_by_range request: %w", err)
 		}
 		blocks = append(blocks, block)
 	}
+
+	// close stream cleanly after successful operation
+	_ = stream.Close()
 	return blocks, nil
 }
 
@@ -301,8 +309,6 @@ func (r *ReqResp) BlocksByRangeV2(ctx context.Context, pid peer.ID, startSlot, f
 	if err != nil {
 		return time.Duration(0), blocks, fmt.Errorf("new %s stream to peer %s: %w", RPCMetaDataTopicV2, pid, err)
 	}
-	defer stream.Close()
-	defer stream.Reset()
 
 	req := &BeaconBlocksByRangeRequestV1{
 		StartSlot: startSlot,
@@ -310,11 +316,12 @@ func (r *ReqResp) BlocksByRangeV2(ctx context.Context, pid peer.ID, startSlot, f
 		Step:      1,
 	}
 	if err := r.writeRequest(stream, req); err != nil {
+		stream.Reset()
 		return time.Duration(0), blocks, fmt.Errorf("write block_by_range request: %w", err)
 	}
 
 	tStart := time.Now()
-	// read and decode status response
+	// read and decode block responses
 	for i := uint64(0); ; i++ {
 		isFirstChunk := i == 0
 		block := &deneb.SignedBeaconBlock{}
@@ -323,11 +330,15 @@ func (r *ReqResp) BlocksByRangeV2(ctx context.Context, pid peer.ID, startSlot, f
 			break
 		}
 		if err != nil {
+			stream.Reset()
 			return time.Duration(0), nil, fmt.Errorf("reading block_by_range request: %w", err)
 		}
 		blocks = append(blocks, block)
 	}
 	opDuration := time.Since(tStart)
+
+	// close stream cleanly after successful operation
+	_ = stream.Close()
 	return opDuration, blocks, nil
 }
 
@@ -344,8 +355,6 @@ func (r *ReqResp) DataColumnByRangeV1(ctx context.Context, pid peer.ID, slot uin
 	if err != nil {
 		return time.Duration(0), dataColumns, fmt.Errorf("new %s stream to peer %s: %w", RPCMetaDataTopicV2, pid, err)
 	}
-	defer stream.Close()
-	defer stream.Reset()
 
 	req := &DataColumnSidecarsByRangeRequestV1{
 		StartSlot: slot,
@@ -353,12 +362,12 @@ func (r *ReqResp) DataColumnByRangeV1(ctx context.Context, pid peer.ID, slot uin
 		Columns:   columnIdxs,
 	}
 	if err := r.writeRequest(stream, req); err != nil {
+		stream.Reset()
 		return time.Duration(0), dataColumns, fmt.Errorf("write data_columns_by_range request: %w", err)
 	}
 
 	tStart := time.Now()
-	// read and decode status response
-
+	// read and decode column sidecar responses
 	for i := uint64(0); ; /* no stop condition */ i++ {
 		dataCol := &DataColumnSidecarV1{}
 		err := r.readChunkedResponse(stream, dataCol, false, r.cfg.ForkDigest(slot))
@@ -368,17 +377,22 @@ func (r *ReqResp) DataColumnByRangeV1(ctx context.Context, pid peer.ID, slot uin
 		}
 
 		if err != nil {
+			stream.Reset()
 			return time.Duration(0), dataColumns, errors.Wrap(err, "read chunked data column sidecar")
 		}
 
 		if i >= chunks {
 			// The response MUST contain no more than `reqCount` blocks.
 			// (`reqCount` is already capped by `maxRequestDataColumnSideCar`.)
+			stream.Reset()
 			return time.Duration(0), dataColumns, errors.New("invalid - response contains more data column sidecars than requested")
 		}
 
 		dataColumns = append(dataColumns, dataCol)
 	}
 	opDuration := time.Since(tStart)
+
+	// close stream cleanly after successful operation
+	_ = stream.Close()
 	return opDuration, dataColumns, nil
 }


### PR DESCRIPTION
- Removed `defer stream.Reset()` and `defer stream.Close()` from most methods.
- Call `stream.Reset()` only on error paths.
- Call `stream.Close()` explicitly at the end of happy paths.
- Inverted conditional logic of `EnsureConnectionToPeer`. If not connected, we should attempt to connect. `Connect()` will block until a connection is open, or an error is returned.
- Sort blob schedule entries by epoch to ensure correct blob parameter computation