### PR TITLE
implement Status and Metadata handlers + close write side of streams on request + misc fixes

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -36,7 +36,7 @@ func Test_ApiGetPeerDASstate(t *testing.T) {
 	httpCli, testMainCtx, cancel := genTestAPICli(t)
 	defer cancel()
 
-	_, err := httpCli.GetPeerDASstate(testMainCtx)
+	_, err := httpCli.GetBeaconStateHead(testMainCtx)
 	require.NoError(t, err)
 }
 

--- a/api/fork_choice.go
+++ b/api/fork_choice.go
@@ -31,8 +31,8 @@ type ForkChoiceNode struct {
 	ExecutionBlockHash string `json:"execution_block_hash"`
 }
 
-func (c *Client) GetForkChoice(ctx context.Context) (ForkChoiceNode, error) {
-	var forkChoice ForkChoiceNode
+func (c *Client) GetForkChoice(ctx context.Context) (ForkChoice, error) {
+	var forkChoice ForkChoice
 
 	resp, err := c.get(ctx, c.cfg.QueryTimeout, ForkChoiceBase, "")
 	if err != nil {

--- a/api/node_identity.go
+++ b/api/node_identity.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 )
 
@@ -17,10 +18,10 @@ type NodeIdentity struct {
 		Maddrs     []string `json:"p2p_addresses"`
 		DiscvAddrs []string `json:"discovery_addresses"`
 		Metadata   struct {
-			SeqNum   string `json:"seq_number"`
-			Attnets  string `json:"attnets"`
-			Syncnets string `json:"syncnets"`
-			Cgc      string `json:"custody_group_count"`
+			SeqNum   string        `json:"seq_number"`
+			Attnets  hexutil.Bytes `json:"attnets"`
+			Syncnets hexutil.Bytes `json:"syncnets"`
+			Cgc      string        `json:"custody_group_count"`
 		} `json:"metadata"`
 	} `json:"data"`
 }
@@ -29,11 +30,11 @@ func (i *NodeIdentity) CustodyInt() (int, error) {
 	return strconv.Atoi(i.Data.Metadata.Cgc)
 }
 
-func (i *NodeIdentity) Attnets() string {
+func (i *NodeIdentity) Attnets() []byte {
 	return i.Data.Metadata.Attnets
 }
 
-func (i *NodeIdentity) Syncnets() string {
+func (i *NodeIdentity) Syncnets() []byte {
 	return i.Data.Metadata.Syncnets
 }
 

--- a/api/node_identity.go
+++ b/api/node_identity.go
@@ -43,7 +43,7 @@ func (i *NodeIdentity) Syncnets() []byte {
 	// TODO remove patch for Prysm, adding dummy data in missing fields.
 	// https://github.com/OffchainLabs/prysm/pull/15506
 	if i.Data.Metadata.Syncnets == nil {
-		return []byte{0x01}
+		return []byte{0x00}
 	}
 	return i.Data.Metadata.Syncnets
 }

--- a/api/node_identity.go
+++ b/api/node_identity.go
@@ -27,6 +27,11 @@ type NodeIdentity struct {
 }
 
 func (i *NodeIdentity) CustodyInt() (int, error) {
+	// TODO remove patch for Prysm, adding dummy data in missing fields.
+	// https://github.com/OffchainLabs/prysm/pull/15506
+	if i.Data.Metadata.Cgc == "" {
+		return 128, nil
+	}
 	return strconv.Atoi(i.Data.Metadata.Cgc)
 }
 
@@ -35,6 +40,11 @@ func (i *NodeIdentity) Attnets() []byte {
 }
 
 func (i *NodeIdentity) Syncnets() []byte {
+	// TODO remove patch for Prysm, adding dummy data in missing fields.
+	// https://github.com/OffchainLabs/prysm/pull/15506
+	if i.Data.Metadata.Syncnets == nil {
+		return []byte{0x01}
+	}
 	return i.Data.Metadata.Syncnets
 }
 

--- a/api/state.go
+++ b/api/state.go
@@ -10,15 +10,15 @@ import (
 
 var BeaconStateBase = "eth/v2/debug/beacon/states/head"
 
-type PeerDASstate struct {
+type BeaconState struct {
 	Version             string              `json:"version"`
 	ExecutionOptimistic bool                `json:"execution_optimistic"`
 	Finalized           bool                `json:"finalized"`
 	Data                electra.BeaconState `json:"data"`
 }
 
-func (c *Client) GetPeerDASstate(ctx context.Context) (PeerDASstate, error) {
-	var state PeerDASstate
+func (c *Client) GetBeaconStateHead(ctx context.Context) (BeaconState, error) {
+	var state BeaconState
 
 	resp, err := c.get(ctx, c.cfg.QueryTimeout, BeaconStateBase, "")
 	if err != nil {

--- a/beacon_api.go
+++ b/beacon_api.go
@@ -55,6 +55,7 @@ func NewBeaconAPI(cfg BeaconAPIConfig) (BeaconAPI, error) {
 		Endpoint:     cfg.Endpoint,
 		StateTimeout: ApiStateTimeout,
 		QueryTimeout: ApiQueryTimeout,
+		Logger:       cfg.Logger,
 	}
 	apiCli, err := api.NewClient(ethApiCfg)
 	if err != nil {

--- a/custody_utils.go
+++ b/custody_utils.go
@@ -2,13 +2,12 @@ package dasguardian
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"math"
 	"sort"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/holiman/uint256"
-	errors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -39,15 +38,12 @@ type AttnetsEntry []byte
 
 func (c AttnetsEntry) ENRKey() string { return "attnets" }
 
-func GetAttnetsFromEnr(ethNode *enode.Node) string {
+func GetAttnetsFromEnr(ethNode *enode.Node) (AttnetsEntry, error) {
 	enr := ethNode.Record()
 
 	var attnetsEntry AttnetsEntry
 	err := enr.Load(&attnetsEntry)
-	if err != nil {
-		return "no-attnets"
-	}
-	return "0x" + hex.EncodeToString(attnetsEntry)
+	return attnetsEntry, err
 }
 
 // syncnets
@@ -55,15 +51,12 @@ type SyncnetsEntry []byte
 
 func (c SyncnetsEntry) ENRKey() string { return "syncnets" }
 
-func GetSyncnetsFromEnr(ethNode *enode.Node) string {
+func GetSyncnetsFromEnr(ethNode *enode.Node) (SyncnetsEntry, error) {
 	enr := ethNode.Record()
 
 	var syncnetsEntry SyncnetsEntry
 	err := enr.Load(&syncnetsEntry)
-	if err != nil {
-		return "no-syncnets"
-	}
-	return "0x" + hex.EncodeToString(syncnetsEntry)
+	return syncnetsEntry, err
 }
 
 // Mainly from: prysm/beacon-chain/core/peerdas/helpers.go

--- a/custody_utils.go
+++ b/custody_utils.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/holiman/uint256"
 	"github.com/pkg/errors"
 )
@@ -52,10 +53,13 @@ type SyncnetsEntry []byte
 func (c SyncnetsEntry) ENRKey() string { return "syncnets" }
 
 func GetSyncnetsFromEnr(ethNode *enode.Node) (SyncnetsEntry, error) {
-	enr := ethNode.Record()
+	record := ethNode.Record()
 
 	var syncnetsEntry SyncnetsEntry
-	err := enr.Load(&syncnetsEntry)
+	err := record.Load(&syncnetsEntry)
+	if enr.IsNotFound(err) {
+		return nil, nil
+	}
 	return syncnetsEntry, err
 }
 

--- a/encoding.go
+++ b/encoding.go
@@ -172,7 +172,7 @@ func (r *ReqResp) writeRequest(stream network.Stream, req any) error {
 		"data_len":  len(data),
 		"wire_data": hexutil.Encode(buf.Bytes()),
 		"wire_len":  buf.Len(),
-	}).Info("writing request")
+	}).Debug("writing request")
 
 	// Write buffer to the stream
 	if _, err := io.Copy(stream, &buf); err != nil {

--- a/encoding.go
+++ b/encoding.go
@@ -128,6 +128,8 @@ func readVarint(r io.Reader) (uint64, error) {
 
 // writeRequest writes a request to the stream with SSZ+Snappy encoding
 func (r *ReqResp) writeRequest(stream network.Stream, req any) error {
+	defer stream.CloseWrite()
+
 	// Set write deadline
 	if err := stream.SetWriteDeadline(time.Now().Add(r.cfg.WriteTimeout)); err != nil {
 		return fmt.Errorf("failed to set write deadline: %w", err)

--- a/guardian.go
+++ b/guardian.go
@@ -832,7 +832,7 @@ func (g *DasGuardian) visualizeBeaconMetadataV2(metadata *MetaDataV2) map[string
 }
 
 func (g *DasGuardian) requestBeaconMetadataV2(ctx context.Context, pid peer.ID) *MetaDataV2 {
-	metadata, err := g.rpcServ.MetaDataV2(ctx, pid, g.localchain.MetaDataV2)
+	metadata, err := g.rpcServ.MetaDataV2(ctx, pid)
 	if err != nil {
 		g.cfg.Logger.Warnf("error requesting beacon-metadata-v2 - %s", err.Error())
 	} else {
@@ -878,7 +878,7 @@ func (g *DasGuardian) requestBeaconMetadataV3(ctx context.Context, pid peer.ID) 
 		}).Debug("Peer protocol support check for MetaDataV3")
 	}
 
-	metadata, err := g.rpcServ.MetaDataV3(ctx, pid, g.localchain.MetaDataV3)
+	metadata, err := g.rpcServ.MetaDataV3(ctx, pid)
 	if err != nil {
 		g.cfg.Logger.WithFields(log.Fields{
 			"peer_id": pid.String(),

--- a/protocol.go
+++ b/protocol.go
@@ -23,6 +23,8 @@ const (
 	RPCDataColumnSidecarsByRootTopicV1  = "/eth2/beacon_chain/req/data_column_sidecars_by_root/1/ssz_snappy"
 )
 
+type ErrorMessage []byte
+
 // Request/Response message types for Ethereum 2.0 P2P protocols
 type SSZUint64 uint64
 

--- a/result_eval.go
+++ b/result_eval.go
@@ -64,7 +64,7 @@ func evaluateColumnResponses(
 			validSlot = (blobCount == 0)
 			if blobCount != 0 {
 				logger.Errorf(
-					"no data cols for slot (downloaded data-cols %d) (block %s)",
+					"no data cols for slot (downloaded data-cols %d) (block %d)",
 					len(cols[s]),
 					slot,
 				)

--- a/rpc_service.go
+++ b/rpc_service.go
@@ -68,10 +68,10 @@ func NewReqResp(h host.Host, cfg *ReqRespConfig) (*ReqResp, error) {
 // values.
 func (r *ReqResp) RegisterHandlers(ctx context.Context) error {
 	handlers := map[string]ContextStreamHandler{
-		RPCPingTopicV1:    r.pingHandler,
-		RPCGoodByeTopicV1: r.goodbyeHandler,
-		RPCStatusTopicV1:  r.dummyHandler,
-		
+		RPCPingTopicV1:                      r.pingHandler,
+		RPCGoodByeTopicV1:                   r.goodbyeHandler,
+		RPCStatusTopicV1:                    r.dummyHandler,
+		RPCStatusTopicV2:                    r.dummyHandler,
 		RPCMetaDataTopicV1:                  r.dummyHandler,
 		RPCMetaDataTopicV2:                  r.dummyHandler,
 		RPCMetaDataTopicV3:                  r.dummyHandler,

--- a/rpc_service.go
+++ b/rpc_service.go
@@ -98,6 +98,8 @@ func (r *ReqResp) RegisterHandlers(ctx context.Context) error {
 
 func (r *ReqResp) wrapStreamHandler(ctx context.Context, name string, handler ContextStreamHandler) network.StreamHandler {
 	return func(s network.Stream) {
+		r.cfg.Logger.WithField("protocol", s.Protocol()).Info("incoming stream")
+
 		// Reset is a no-op if the stream is already closed. Closing the stream
 		// is the responsibility of the handler.
 		defer s.Reset()

--- a/rpc_service.go
+++ b/rpc_service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/protocol"
+
 	log "github.com/sirupsen/logrus"
 )
 

--- a/rpc_service.go
+++ b/rpc_service.go
@@ -11,10 +11,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var (
-	RPCStatusV2 = "/eth2/beacon_chain/req/status/2"
-)
-
 const (
 	// Spec defined codes.
 	GoodbyeCodeClientShutdown uint64 = iota + 1
@@ -72,9 +68,10 @@ func NewReqResp(h host.Host, cfg *ReqRespConfig) (*ReqResp, error) {
 // values.
 func (r *ReqResp) RegisterHandlers(ctx context.Context) error {
 	handlers := map[string]ContextStreamHandler{
-		RPCPingTopicV1:                      r.pingHandler,
-		RPCGoodByeTopicV1:                   r.goodbyeHandler,
-		RPCStatusTopicV1:                    r.dummyHandler,
+		RPCPingTopicV1:    r.pingHandler,
+		RPCGoodByeTopicV1: r.goodbyeHandler,
+		RPCStatusTopicV1:  r.dummyHandler,
+		
 		RPCMetaDataTopicV1:                  r.dummyHandler,
 		RPCMetaDataTopicV2:                  r.dummyHandler,
 		RPCMetaDataTopicV3:                  r.dummyHandler,

--- a/rpcs.go
+++ b/rpcs.go
@@ -208,7 +208,7 @@ func (r *ReqResp) MetaDataV3(ctx context.Context, pid peer.ID, md *MetaDataV3) (
 		}).Debug("Writing MetaDataV3 request with payload")
 	}
 
-	if err := r.writeRequest(stream, md); err != nil {
+	if err := r.writeRequest(stream, nil); err != nil {
 		if log.GetLevel() >= log.DebugLevel {
 			r.cfg.Logger.WithFields(log.Fields{
 				"peer_id": pid.String(),

--- a/rpcs.go
+++ b/rpcs.go
@@ -284,7 +284,7 @@ func (r *ReqResp) RawBlocksByRangeV2(ctx context.Context, pid peer.ID, startSlot
 	for i := uint64(0); ; i++ {
 		isFirstChunk := i == 0
 		block := &deneb.SignedBeaconBlock{}
-		err := r.readChunkedResponse(stream, block, isFirstChunk, r.cfg.ForkDigest(uint64(startSlot)+i))
+		err := r.readChunkedResponse(stream, block, isFirstChunk, r.cfg.ForkDigestFn(uint64(startSlot)+i))
 		if errors.Is(err, io.EOF) {
 			break
 		}
@@ -325,7 +325,7 @@ func (r *ReqResp) BlocksByRangeV2(ctx context.Context, pid peer.ID, startSlot, f
 	for i := uint64(0); ; i++ {
 		isFirstChunk := i == 0
 		block := &deneb.SignedBeaconBlock{}
-		err := r.readChunkedResponse(stream, block, isFirstChunk, r.cfg.ForkDigest(startSlot+i))
+		err := r.readChunkedResponse(stream, block, isFirstChunk, r.cfg.ForkDigestFn(startSlot+i))
 		if errors.Is(err, io.EOF) {
 			break
 		}
@@ -370,7 +370,7 @@ func (r *ReqResp) DataColumnByRangeV1(ctx context.Context, pid peer.ID, slot uin
 	// read and decode column sidecar responses
 	for i := uint64(0); ; /* no stop condition */ i++ {
 		dataCol := &DataColumnSidecarV1{}
-		err := r.readChunkedResponse(stream, dataCol, false, r.cfg.ForkDigest(slot))
+		err := r.readChunkedResponse(stream, dataCol, false, r.cfg.ForkDigestFn(slot))
 		if errors.Is(err, io.EOF) {
 			// End of stream.
 			break

--- a/rpcs.go
+++ b/rpcs.go
@@ -138,10 +138,7 @@ func (r *ReqResp) StatusV2(ctx context.Context, pid peer.ID, st *StatusV2) (stat
 	return resp, nil
 }
 
-func (r *ReqResp) MetaDataV2(ctx context.Context, pid peer.ID, md *MetaDataV2) (resp *MetaDataV2, err error) {
-	if isNill(md) {
-		return nil, fmt.Errorf("the given local-metadata-v2 is a nil pointer")
-	}
+func (r *ReqResp) MetaDataV2(ctx context.Context, pid peer.ID) (resp *MetaDataV2, err error) {
 	if err := r.EnsureConnectionToPeer(ctx, pid); err != nil {
 		return nil, err
 	}
@@ -150,7 +147,7 @@ func (r *ReqResp) MetaDataV2(ctx context.Context, pid peer.ID, md *MetaDataV2) (
 		return resp, fmt.Errorf("new %s stream to peer %s: %w", RPCMetaDataTopicV2, pid, err)
 	}
 
-	if err := r.writeRequest(stream, md); err != nil {
+	if err := r.writeRequest(stream, r.cfg.ChainData.MetaDataV2); err != nil {
 		stream.Reset()
 		return nil, fmt.Errorf("write metadata-v2 request: %w", err)
 	}
@@ -168,10 +165,7 @@ func (r *ReqResp) MetaDataV2(ctx context.Context, pid peer.ID, md *MetaDataV2) (
 	return resp, nil
 }
 
-func (r *ReqResp) MetaDataV3(ctx context.Context, pid peer.ID, md *MetaDataV3) (resp *MetaDataV3, err error) {
-	if isNill(md) {
-		return nil, fmt.Errorf("the given local-metadata-v3 is a nil pointer")
-	}
+func (r *ReqResp) MetaDataV3(ctx context.Context, pid peer.ID) (resp *MetaDataV3, err error) {
 	if err := r.EnsureConnectionToPeer(ctx, pid); err != nil {
 		if log.GetLevel() >= log.DebugLevel {
 			r.cfg.Logger.WithFields(log.Fields{
@@ -201,17 +195,19 @@ func (r *ReqResp) MetaDataV3(ctx context.Context, pid peer.ID, md *MetaDataV3) (
 		return resp, fmt.Errorf("new %s stream to peer %s: %w", RPCMetaDataTopicV3, pid, err)
 	}
 
+	req := r.cfg.ChainData.MetaDataV3
+
 	if log.GetLevel() >= log.DebugLevel {
 		r.cfg.Logger.WithFields(log.Fields{
 			"peer_id":                     pid.String(),
-			"request_seq_number":          md.SeqNumber,
-			"request_attnets":             fmt.Sprintf("0x%x", md.Attnets),
-			"request_syncnets":            fmt.Sprintf("0x%x", md.Syncnets),
-			"request_custody_group_count": md.CustodyGroupCount,
+			"request_seq_number":          req.SeqNumber,
+			"request_attnets":             fmt.Sprintf("0x%x", req.Attnets),
+			"request_syncnets":            fmt.Sprintf("0x%x", req.Syncnets),
+			"request_custody_group_count": req.CustodyGroupCount,
 		}).Debug("Writing MetaDataV3 request with payload")
 	}
 
-	if err := r.writeRequest(stream, nil); err != nil {
+	if err := r.writeRequest(stream, req); err != nil {
 		stream.Reset()
 		if log.GetLevel() >= log.DebugLevel {
 			r.cfg.Logger.WithFields(log.Fields{

--- a/rpcs.go
+++ b/rpcs.go
@@ -147,7 +147,7 @@ func (r *ReqResp) MetaDataV2(ctx context.Context, pid peer.ID) (resp *MetaDataV2
 		return resp, fmt.Errorf("new %s stream to peer %s: %w", RPCMetaDataTopicV2, pid, err)
 	}
 
-	if err := r.writeRequest(stream, r.cfg.ChainData.MetaDataV2); err != nil {
+	if err := r.writeRequest(stream, nil); err != nil {
 		stream.Reset()
 		return nil, fmt.Errorf("write metadata-v2 request: %w", err)
 	}
@@ -195,19 +195,7 @@ func (r *ReqResp) MetaDataV3(ctx context.Context, pid peer.ID) (resp *MetaDataV3
 		return resp, fmt.Errorf("new %s stream to peer %s: %w", RPCMetaDataTopicV3, pid, err)
 	}
 
-	req := r.cfg.ChainData.MetaDataV3
-
-	if log.GetLevel() >= log.DebugLevel {
-		r.cfg.Logger.WithFields(log.Fields{
-			"peer_id":                     pid.String(),
-			"request_seq_number":          req.SeqNumber,
-			"request_attnets":             fmt.Sprintf("0x%x", req.Attnets),
-			"request_syncnets":            fmt.Sprintf("0x%x", req.Syncnets),
-			"request_custody_group_count": req.CustodyGroupCount,
-		}).Debug("Writing MetaDataV3 request with payload")
-	}
-
-	if err := r.writeRequest(stream, req); err != nil {
+	if err := r.writeRequest(stream, nil); err != nil {
 		stream.Reset()
 		if log.GetLevel() >= log.DebugLevel {
 			r.cfg.Logger.WithFields(log.Fields{


### PR DESCRIPTION
This is the result of a debugging session to pinpoint compatibility issues with various clients (chiefly Nimbus and Teku). The commit log breaks down what was done here, but the highlights are:

- implement Status and Metadata handlers
- send non-dummy Status and Metadata of ourselves, mostly echoed from the node under test
- most importantly: close the write side of streams after sending a request
- log the error message returned by the peer on failed RPCs (these were crucial to get to the root cause)

Lowlights include refactoring for DRYness, extra logging, and temporary workarounds to deal with client bugs, e.g. Prysm outdated Metadata struct on the beacon API (https://github.com/OffchainLabs/prysm/pull/15506).