### PR TITLE
Support devnet network level scans (playtime)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 # scripts
 *.sh
 notes.md
+.logs/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To function correctly, the tool adheres to the networking requirements outlined 
 - `Go >=1.24`
 - (Recommended) [Just](https://github.com/casey/just)
 - A Beacon API with debugging events enabled (the tool downloads the beacon-state from the node)
-  - Example: use EthPandaOps’ Beacon RPC endpoint listed in the [devnet details](https://peerdas-devnet-7.ethpandaops.io/)
+  - Example: use EthPandaOps’ Beacon RPC endpoint listed in the [devnet details](https://fusaka-devnet-3.ethpandaops.io/)
 
 ## Installation
 
@@ -59,11 +59,13 @@ USAGE:
    das-guardian [global options] [command [command options]]
 
 COMMANDS:
-   scan     Connects and scans a given node for its custody and network status
-   monitor  Connects and monitors a given node for its custody and network status
-   help, h  Shows a list of commands or help for one command
+   scan      Connects and scans a given node for its custody and network status
+   monitor   Connects and monitors a given node for its custody and network status
+   playtime  Run monitor or scan commands on all consensus clients from Dora
+   help, h   Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
+   --log.level string             Level of the logs (default: "info")
    --libp2p.host string           IP for the Libp2p host (default: "127.0.0.1")
    --libp2p.port int              Port for the libp2p host (default: 9013)
    --api.endpoint string          The url endpoint of a Beacon API (http://localhost:5052/) (default: "http://127.0.0.1:5052/")

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It can extract and present all available information for a given [ENR](https://g
 This experimental version of the tool is compatible with existing PeerDAS devnets. It has been tested and confirmed to work with `fusaka-devnet-2`.
 
 More details available at:
-- EF's [fusaka-devnet-2 dashboard](https://fusaka-devnet-2.ethpandaops.io/)
+- EF's [fusaka-devnet-3 dashboard](https://fusaka-devnet-3.ethpandaops.io/)
 
 ## PeerDAS Specifications
 

--- a/api/block.go
+++ b/api/block.go
@@ -11,7 +11,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-var BlockBase = "eth/v2/beacon/blocks/%d"
+var (
+	BlockBase        = "eth/v2/beacon/blocks/"
+	ErrBlockNotFound = fmt.Errorf("block not found")
+)
 
 type BeaconBlock struct {
 	Version             string                     `json:"version"`
@@ -32,16 +35,26 @@ type FuluBeaconBlock struct {
 	Body          electra.BeaconBlockBody `json:"body"`
 }
 
-func (c *Client) GetBeaconBlock(ctx context.Context, slot uint64) (*spec.VersionedSignedBeaconBlock, error) {
+func (c *Client) GetBeaconBlock(ctx context.Context, slot any) (*spec.VersionedSignedBeaconBlock, error) {
+	// we only accept integers and strings to describe the slots
+	blockQuery := BlockBase
+	switch s := slot.(type) {
+	case int, int32, int64, uint, uint32, uint64:
+		blockQuery = blockQuery + fmt.Sprintf("%d", s)
+	case string:
+		blockQuery = s
+	default:
+		return nil, fmt.Errorf("unrecognized slot %s", slot)
+	}
+
 	versionedBlock := &spec.VersionedSignedBeaconBlock{
 		Version: spec.DataVersionElectra,
 	}
 	beaconBlock := &BeaconBlock{}
-	resp, err := c.get(ctx, c.cfg.QueryTimeout, fmt.Sprintf(BlockBase, slot), "")
+	resp, err := c.get(ctx, c.cfg.QueryTimeout, blockQuery, "")
 	if err != nil {
 		if strings.Contains(err.Error(), "404 Not Found") {
-			fmt.Println("not found!")
-			return new(spec.VersionedSignedBeaconBlock), nil
+			return new(spec.VersionedSignedBeaconBlock), ErrBlockNotFound
 		}
 		return nil, errors.Wrap(err, "requesting beacon-block")
 	}

--- a/api/block.go
+++ b/api/block.go
@@ -42,7 +42,7 @@ func (c *Client) GetBeaconBlock(ctx context.Context, slot any) (*spec.VersionedS
 	case int, int32, int64, uint, uint32, uint64:
 		blockQuery = blockQuery + fmt.Sprintf("%d", s)
 	case string:
-		blockQuery = s
+		blockQuery = blockQuery + s
 	default:
 		return nil, fmt.Errorf("unrecognized slot %s", slot)
 	}

--- a/api/client.go
+++ b/api/client.go
@@ -18,7 +18,7 @@ type ClientConfig struct {
 	StateTimeout   time.Duration
 	QueryTimeout   time.Duration
 	CustomClClient string
-	Logger         log.FieldLogger
+	Logger         *log.Logger
 }
 
 type Client struct {
@@ -61,7 +61,7 @@ func (c *Client) CheckConnection(ctx context.Context) error {
 		return errors.Wrap(err, "testing connectivity")
 	}
 
-	log.WithFields(log.Fields{
+	c.cfg.Logger.WithFields(log.Fields{
 		"node-version": version.Data.Version,
 	}).Info("successfull connection to the beacon-api")
 

--- a/api/client.go
+++ b/api/client.go
@@ -42,7 +42,7 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 
 	urlBase, err := url.Parse(cfg.Endpoint)
 	if err != nil {
-		return nil, errors.Wrap(err, "composing Avail API's base URL")
+		return nil, errors.Wrap(err, "composing API's base URL")
 	}
 
 	cli := &Client{

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	devnetBeaconAPI = "https://beacon.fusaka-devnet-2.ethpandaops.io/"
+	devnetBeaconAPI = "https://beacon.fusaka-devnet-3.ethpandaops.io/"
 	StateTimeout    = 30 * time.Second
 	QueryTimeout    = 10 * time.Second
 )

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -101,7 +101,7 @@ func genTestAPICli(t *testing.T) (*Client, context.Context, context.CancelFunc) 
 		Endpoint:     devnetBeaconAPI,
 		StateTimeout: StateTimeout,
 		QueryTimeout: QueryTimeout,
-		Logger:       log.WithFields(log.Fields{}),
+		Logger:       log.New(),
 	}
 
 	httpCli, err := NewClient(cfg)

--- a/beacon_api.go
+++ b/beacon_api.go
@@ -31,7 +31,7 @@ type BeaconAPI interface {
 	GetLatestBlockHeader() *phase0.BeaconBlockHeader
 	GetFuluForkEpoch() uint64
 	GetNodeIdentity(context.Context) (*api.NodeIdentity, error)
-	GetBeaconBlock(ctx context.Context, slot uint64) (*spec.VersionedSignedBeaconBlock, error)
+	GetBeaconBlock(ctx context.Context, slot any) (*spec.VersionedSignedBeaconBlock, error)
 	ReadSpecParameter(key string) (any, bool)
 }
 
@@ -419,7 +419,7 @@ func (b *BeaconAPIImpl) GetNodeIdentity(ctx context.Context) (*api.NodeIdentity,
 	return b.apiClient.GetNodeIdentity(ctx)
 }
 
-func (b *BeaconAPIImpl) GetBeaconBlock(ctx context.Context, slot uint64) (*spec.VersionedSignedBeaconBlock, error) {
+func (b *BeaconAPIImpl) GetBeaconBlock(ctx context.Context, slot any) (*spec.VersionedSignedBeaconBlock, error) {
 	return b.apiClient.GetBeaconBlock(ctx, slot)
 }
 

--- a/beacon_api.go
+++ b/beacon_api.go
@@ -36,7 +36,7 @@ type BeaconAPI interface {
 }
 
 type BeaconAPIConfig struct {
-	Logger         log.FieldLogger
+	Logger         *log.Logger
 	Endpoint       string
 	WaitForFulu    bool
 	CustomClClient string

--- a/beacon_api_mock.go
+++ b/beacon_api_mock.go
@@ -61,7 +61,7 @@ func (m *mockBeaconAPI) GetNodeIdentity(ctx context.Context) (*api.NodeIdentity,
 	return args.Get(0).(*api.NodeIdentity), args.Error(1)
 }
 
-func (m *mockBeaconAPI) GetBeaconBlock(ctx context.Context, slot uint64) (*spec.VersionedSignedBeaconBlock, error) {
+func (m *mockBeaconAPI) GetBeaconBlock(ctx context.Context, slot any) (*spec.VersionedSignedBeaconBlock, error) {
 	args := m.Called(ctx, slot)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -73,7 +73,7 @@ func monitorAction(ctx context.Context, cmd *cli.Command) error {
 		"slot-range-slots":   scanConfig.SlotCustomRange,
 	}).Info("running das-guardian")
 
-	logger := log.WithFields(log.Fields{})
+	logger := log.New()
 	logger.WithFields(log.Fields{
 		"freq": monitorConfig.MonitorFrequency,
 	}).Info("monitor cmd...")

--- a/cmd/playtime.go
+++ b/cmd/playtime.go
@@ -2,47 +2,24 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"os"
-	"sync"
-	"time"
 
-	"github.com/probe-lab/eth-das-guardian/dora"
+	dasguardian "github.com/probe-lab/eth-das-guardian"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v3"
 )
 
-// ClientStatus represents the execution status of a client
-type ClientStatus int
-
-const (
-	StatusPending ClientStatus = iota
-	StatusRunning
-	StatusSuccess
-	StatusFailed
-)
-
-// ClientResult holds the result of processing a client
-type ClientResult struct {
-	DoraInfo dora.ConsensusClientNodeInfo
-	Status   ClientStatus
-	Error    error
-}
-
-var (
-	gridMutex sync.RWMutex
-	stopGrid  chan struct{}
-)
-
 var playTimeConfig = struct {
-	Parallelism  int32
-	DoraEndpoint string
-	LogDir       string
+	Parallelism    int32
+	DoraEndpoint   string
+	BeaconEndpoint string
+	LogDir         string
+	DryScan        bool
 }{
-	Parallelism:  4,
-	DoraEndpoint: "https://dora.fusaka-devnet-2.ethpandaops.io/api/",
-	LogDir:       ".logs",
+	Parallelism:    4,
+	DoraEndpoint:   "https://dora.fusaka-devnet-2.ethpandaops.io/api/",
+	BeaconEndpoint: "https://beacon.fusaka-devnet-2.ethpandaops.io/",
+	LogDir:         ".logs",
+	DryScan:        true,
 }
 
 var cmdPlaytime = &cli.Command{
@@ -67,279 +44,41 @@ var cmdPlaytime = &cli.Command{
 			Destination: &playTimeConfig.DoraEndpoint,
 		},
 		&cli.StringFlag{
+			Name:        "beacon-endpoint",
+			Usage:       "HTTPs endpoint of a trusted beacon API",
+			Value:       playTimeConfig.BeaconEndpoint,
+			Destination: &playTimeConfig.BeaconEndpoint,
+		},
+		&cli.StringFlag{
 			Name:        "log-dir",
 			Usage:       "Directory to write log files",
 			Value:       playTimeConfig.LogDir,
 			Destination: &playTimeConfig.LogDir,
+		},
+		&cli.BoolFlag{
+			Name:        "dry-scan",
+			Usage:       "",
+			Value:       playTimeConfig.DryScan,
+			Destination: &playTimeConfig.DryScan,
 		},
 	},
 	Action: runPlaytime,
 }
 
 func runPlaytime(ctx context.Context, cmd *cli.Command) error {
-	// logrus to keep the logs in the same folder
-	if err := ensureLogPath(playTimeConfig.LogDir); err != nil {
-		return fmt.Errorf("unable to create log-folder at %s - %w", playTimeConfig.LogDir, err)
+	devnetScanCfg := dasguardian.DevnetScannerConfig{
+		LogLevel:          dasguardian.ParseLogLevel(rootConfig.LogLevel),
+		LogFormat:         &logrus.JSONFormatter{},
+		LogDir:            playTimeConfig.LogDir,
+		Parallelism:       playTimeConfig.Parallelism,
+		DoraApiEndpoint:   playTimeConfig.DoraEndpoint,
+		BeaconApiEndpoint: playTimeConfig.BeaconEndpoint,
+		DryScan:           playTimeConfig.DryScan,
 	}
-
-	mainLogsFile := playTimeConfig.LogDir + "/main.logs"
-	f, err := os.OpenFile(mainLogsFile, os.O_CREATE|os.O_WRONLY, 0755)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	// init logrus to keep logs in the previously create folder
-	logrus.SetFormatter(&logrus.JSONFormatter{})
-	logrus.SetOutput(f)
-	logrus.SetLevel(ParseLogLevel(rootConfig.LogLevel))
-
-	doraApiCli, err := dora.NewClient(dora.ClientConfig{
-		Endpoint:     playTimeConfig.DoraEndpoint,
-		QueryTimeout: 10 * time.Second,
-		Logger:       logrus.New(),
-	})
-
-	consensusClients, err := doraApiCli.GetConsensusClients(ctx)
+	devnetScanner, err := dasguardian.NewDevnetScanner(devnetScanCfg)
 	if err != nil {
 		return err
 	}
 
-	if consensusClients.Count == 0 {
-		logrus.Error("No clients found from Dora API")
-		return nil
-	}
-
-	// Initialize client results
-	results := make(map[string]*ClientResult)
-	for _, client := range consensusClients.Clients {
-		results[client.PeerID] = &ClientResult{
-			DoraInfo: client,
-			Status:   StatusPending,
-		}
-		logrus.WithFields(logrus.Fields{
-			"client-name": client.ClientName,
-			"version":     client.Version,
-		}).Info("new consensus node")
-	}
-
-	// Start live grid updates
-	stopGrid = make(chan struct{})
-	go startLiveGridUpdates(results)
-
-	// Display initial grid
-	displayGrid(results)
-
-	// process clients in parallel
-	// TODO:
-
-	// Stop live updates and display final grid
-	close(stopGrid)
-	displayGrid(results)
-
-	if err != nil {
-		return err
-	}
-
-	// Print summary
-	printSummary(results)
-
-	return nil
-}
-
-func ensureLogPath(path string) error {
-	_, err := os.Stat(path)
-	if err != nil {
-		// only create the folder if it doesn't exists
-		return os.Mkdir(path, 0755)
-	} else {
-		return err
-	}
-}
-
-func startLiveGridUpdates(results map[string]*ClientResult) {
-	ticker := time.NewTicker(500 * time.Millisecond) // Update every 500ms
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			displayGrid(results)
-		case <-stopGrid:
-			return
-		}
-	}
-}
-
-func executeScan(ctx context.Context, beaconURL, logFile string) error {
-	// Create log file
-	file, err := os.Create(logFile)
-	if err != nil {
-		return fmt.Errorf("failed to create log file: %w", err)
-	}
-	defer file.Close()
-
-	// Create a logger that writes to the file
-	logger := logrus.New()
-	logger.SetOutput(file)
-
-	// Create a context with timeout to prevent hanging
-	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-	defer cancel()
-
-	// Call the scarusn function with the beacon URL
-	// We need to temporarily override the global config for this execution
-	originalEndpoint := rootConfig.BeaconAPIendpoint
-	rootConfig.BeaconAPIendpoint = beaconURL
-	defer func() {
-		rootConfig.BeaconAPIendpoint = originalEndpoint
-	}()
-
-	// Create a fake CLI context to pass to the scan command
-	return runScan(timeoutCtx, logger, file)
-}
-
-func runScan(ctx context.Context, logger *logrus.Logger, output io.Writer) error {
-	// This should call your existing scan logic
-	// You'll need to extract the actual logic from cmdScan.Action
-	// and make it callable with custom parameters
-
-	fmt.Fprintf(output, "Scan started for %s at %s\n", rootConfig.BeaconAPIendpoint, time.Now())
-
-	// TODO: Replace this with actual scan logic
-	// Example: return scan.Run(ctx, rootConfig, logger)
-
-	// Simulate some work
-	time.Sleep(1 * time.Second)
-
-	fmt.Fprintf(output, "Scan completed for %s at %s\n", rootConfig.BeaconAPIendpoint, time.Now())
-	return nil
-}
-
-func displayGrid(results map[string]*ClientResult) {
-	gridMutex.RLock()
-	defer gridMutex.RUnlock()
-
-	// Clear screen and move cursor to top
-	fmt.Print("\033[2J\033[H")
-
-	fmt.Println("Consensus Clients Status:")
-	fmt.Println("========================")
-
-	const colWidth = 20
-	const cols = 4
-
-	clients := make([]*ClientResult, 0, len(results))
-	for _, result := range results {
-		clients = append(clients, result)
-	}
-
-	for i := 0; i < len(clients); i += cols {
-		for j := 0; j < cols && i+j < len(clients); j++ {
-			client := clients[i+j]
-			status := getStatusDisplay(client.Status)
-			clientName := client.DoraInfo.ClientName
-			if len(clientName) > 15 {
-				clientName = clientName[:15] + "..."
-			}
-			fmt.Printf("%-*s", colWidth, fmt.Sprintf("%s %s", status, clientName))
-		}
-		fmt.Println()
-	}
-
-	fmt.Println()
-	fmt.Println("Legend: 🟡 Running, 🟢 Success, 🔴 Failed, ⚪ Pending")
-
-	// Show current counts
-	var pending, running, success, failed int
-	for _, result := range results {
-		switch result.Status {
-		case StatusPending:
-			pending++
-		case StatusRunning:
-			running++
-		case StatusSuccess:
-			success++
-		case StatusFailed:
-			failed++
-		}
-	}
-
-	fmt.Printf("Status: %d pending, %d running, %d success, %d failed\n",
-		pending, running, success, failed)
-	fmt.Println()
-}
-
-func getStatusDisplay(status ClientStatus) string {
-	switch status {
-	case StatusPending:
-		return "⚪"
-	case StatusRunning:
-		return "\033[33m🟡\033[0m" // Yellow
-	case StatusSuccess:
-		return "\033[32m🟢\033[0m" // Green
-	case StatusFailed:
-		return "\033[31m🔴\033[0m" // Red
-	default:
-		return "⚪"
-	}
-}
-
-func printSummary(results map[string]*ClientResult) {
-	var pending, running, success, failed int
-
-	for _, result := range results {
-		switch result.Status {
-		case StatusPending:
-			pending++
-		case StatusRunning:
-			running++
-		case StatusSuccess:
-			success++
-		case StatusFailed:
-			failed++
-		}
-	}
-
-	fmt.Printf("\nFinal Summary: %d total, %d success, %d failed, %d pending, %d running\n",
-		len(results), success, failed, pending, running)
-
-	// Print failed clients with errors
-	if failed > 0 {
-		fmt.Println("\nFailed clients:")
-		for _, result := range results {
-			if result.Status == StatusFailed {
-				fmt.Printf("  %s: %v\n", result.DoraInfo.ClientName, result.Error)
-			}
-		}
-	}
-
-	// Print successful clients
-	if success > 0 {
-		fmt.Println("\nSuccessful clients:")
-		for _, result := range results {
-			if result.Status == StatusSuccess {
-				fmt.Printf("  %s: completed successfully\n", result.DoraInfo.ClientName)
-			}
-		}
-	}
-}
-
-func configureGlobalLogger(logDir string) error {
-	// logrus to keep the logs in the same folder
-	if err := ensureLogPath(logDir); err != nil {
-		return fmt.Errorf("unable to create log-folder at %s - %w", logDir, err)
-	}
-
-	mainLogsFile := logDir + "/main.logs"
-	f, err := os.OpenFile(mainLogsFile, os.O_CREATE|os.O_WRONLY, 0755)
-	if err != nil {
-		return err
-	}
-
-	// init logrus to keep logs in the previously create folder
-	logrus.SetFormatter(&logrus.JSONFormatter{})
-	logrus.SetOutput(f)
-	logrus.SetLevel(ParseLogLevel(rootConfig.LogLevel))
-	return nil
+	return devnetScanner.Start(ctx)
 }

--- a/cmd/playtime.go
+++ b/cmd/playtime.go
@@ -1,0 +1,345 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/probe-lab/eth-das-guardian/dora"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v3"
+)
+
+// ClientStatus represents the execution status of a client
+type ClientStatus int
+
+const (
+	StatusPending ClientStatus = iota
+	StatusRunning
+	StatusSuccess
+	StatusFailed
+)
+
+// ClientResult holds the result of processing a client
+type ClientResult struct {
+	DoraInfo dora.ConsensusClientNodeInfo
+	Status   ClientStatus
+	Error    error
+}
+
+var (
+	gridMutex sync.RWMutex
+	stopGrid  chan struct{}
+)
+
+var playTimeConfig = struct {
+	Parallelism  int32
+	DoraEndpoint string
+	LogDir       string
+}{
+	Parallelism:  4,
+	DoraEndpoint: "https://dora.fusaka-devnet-2.ethpandaops.io/api/",
+	LogDir:       ".logs",
+}
+
+var cmdPlaytime = &cli.Command{
+	Name:  "playtime",
+	Usage: "Run monitor or scan commands on all consensus clients from Dora",
+	Description: `Fetches all consensus clients from Dora API and runs the specified command
+(monitor or scan) on each client in parallel.`,
+	Arguments: []cli.Argument{&cli.StringArg{
+		Name: "command",
+	}},
+	Flags: []cli.Flag{
+		&cli.Int32Flag{
+			Name:        "parallelism",
+			Usage:       "Number of parallel executions",
+			Value:       playTimeConfig.Parallelism,
+			Destination: &playTimeConfig.Parallelism,
+		},
+		&cli.StringFlag{
+			Name:        "dora-endpoint",
+			Usage:       "HTTPs endpoint of the dora API",
+			Value:       playTimeConfig.DoraEndpoint,
+			Destination: &playTimeConfig.DoraEndpoint,
+		},
+		&cli.StringFlag{
+			Name:        "log-dir",
+			Usage:       "Directory to write log files",
+			Value:       playTimeConfig.LogDir,
+			Destination: &playTimeConfig.LogDir,
+		},
+	},
+	Action: runPlaytime,
+}
+
+func runPlaytime(ctx context.Context, cmd *cli.Command) error {
+	// logrus to keep the logs in the same folder
+	if err := ensureLogPath(playTimeConfig.LogDir); err != nil {
+		return fmt.Errorf("unable to create log-folder at %s - %w", playTimeConfig.LogDir, err)
+	}
+
+	mainLogsFile := playTimeConfig.LogDir + "/main.logs"
+	f, err := os.OpenFile(mainLogsFile, os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// init logrus to keep logs in the previously create folder
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetOutput(f)
+	logrus.SetLevel(ParseLogLevel(rootConfig.LogLevel))
+
+	doraApiCli, err := dora.NewClient(dora.ClientConfig{
+		Endpoint:     playTimeConfig.DoraEndpoint,
+		QueryTimeout: 10 * time.Second,
+		Logger:       logrus.New(),
+	})
+
+	consensusClients, err := doraApiCli.GetConsensusClients(ctx)
+	if err != nil {
+		return err
+	}
+
+	if consensusClients.Count == 0 {
+		logrus.Error("No clients found from Dora API")
+		return nil
+	}
+
+	// Initialize client results
+	results := make(map[string]*ClientResult)
+	for _, client := range consensusClients.Clients {
+		results[client.PeerID] = &ClientResult{
+			DoraInfo: client,
+			Status:   StatusPending,
+		}
+		logrus.WithFields(logrus.Fields{
+			"client-name": client.ClientName,
+			"version":     client.Version,
+		}).Info("new consensus node")
+	}
+
+	// Start live grid updates
+	stopGrid = make(chan struct{})
+	go startLiveGridUpdates(results)
+
+	// Display initial grid
+	displayGrid(results)
+
+	// process clients in parallel
+	// TODO:
+
+	// Stop live updates and display final grid
+	close(stopGrid)
+	displayGrid(results)
+
+	if err != nil {
+		return err
+	}
+
+	// Print summary
+	printSummary(results)
+
+	return nil
+}
+
+func ensureLogPath(path string) error {
+	_, err := os.Stat(path)
+	if err != nil {
+		// only create the folder if it doesn't exists
+		return os.Mkdir(path, 0755)
+	} else {
+		return err
+	}
+}
+
+func startLiveGridUpdates(results map[string]*ClientResult) {
+	ticker := time.NewTicker(500 * time.Millisecond) // Update every 500ms
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			displayGrid(results)
+		case <-stopGrid:
+			return
+		}
+	}
+}
+
+func executeScan(ctx context.Context, beaconURL, logFile string) error {
+	// Create log file
+	file, err := os.Create(logFile)
+	if err != nil {
+		return fmt.Errorf("failed to create log file: %w", err)
+	}
+	defer file.Close()
+
+	// Create a logger that writes to the file
+	logger := logrus.New()
+	logger.SetOutput(file)
+
+	// Create a context with timeout to prevent hanging
+	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	// Call the scarusn function with the beacon URL
+	// We need to temporarily override the global config for this execution
+	originalEndpoint := rootConfig.BeaconAPIendpoint
+	rootConfig.BeaconAPIendpoint = beaconURL
+	defer func() {
+		rootConfig.BeaconAPIendpoint = originalEndpoint
+	}()
+
+	// Create a fake CLI context to pass to the scan command
+	return runScan(timeoutCtx, logger, file)
+}
+
+func runScan(ctx context.Context, logger *logrus.Logger, output io.Writer) error {
+	// This should call your existing scan logic
+	// You'll need to extract the actual logic from cmdScan.Action
+	// and make it callable with custom parameters
+
+	fmt.Fprintf(output, "Scan started for %s at %s\n", rootConfig.BeaconAPIendpoint, time.Now())
+
+	// TODO: Replace this with actual scan logic
+	// Example: return scan.Run(ctx, rootConfig, logger)
+
+	// Simulate some work
+	time.Sleep(1 * time.Second)
+
+	fmt.Fprintf(output, "Scan completed for %s at %s\n", rootConfig.BeaconAPIendpoint, time.Now())
+	return nil
+}
+
+func displayGrid(results map[string]*ClientResult) {
+	gridMutex.RLock()
+	defer gridMutex.RUnlock()
+
+	// Clear screen and move cursor to top
+	fmt.Print("\033[2J\033[H")
+
+	fmt.Println("Consensus Clients Status:")
+	fmt.Println("========================")
+
+	const colWidth = 20
+	const cols = 4
+
+	clients := make([]*ClientResult, 0, len(results))
+	for _, result := range results {
+		clients = append(clients, result)
+	}
+
+	for i := 0; i < len(clients); i += cols {
+		for j := 0; j < cols && i+j < len(clients); j++ {
+			client := clients[i+j]
+			status := getStatusDisplay(client.Status)
+			clientName := client.DoraInfo.ClientName
+			if len(clientName) > 15 {
+				clientName = clientName[:15] + "..."
+			}
+			fmt.Printf("%-*s", colWidth, fmt.Sprintf("%s %s", status, clientName))
+		}
+		fmt.Println()
+	}
+
+	fmt.Println()
+	fmt.Println("Legend: 🟡 Running, 🟢 Success, 🔴 Failed, ⚪ Pending")
+
+	// Show current counts
+	var pending, running, success, failed int
+	for _, result := range results {
+		switch result.Status {
+		case StatusPending:
+			pending++
+		case StatusRunning:
+			running++
+		case StatusSuccess:
+			success++
+		case StatusFailed:
+			failed++
+		}
+	}
+
+	fmt.Printf("Status: %d pending, %d running, %d success, %d failed\n",
+		pending, running, success, failed)
+	fmt.Println()
+}
+
+func getStatusDisplay(status ClientStatus) string {
+	switch status {
+	case StatusPending:
+		return "⚪"
+	case StatusRunning:
+		return "\033[33m🟡\033[0m" // Yellow
+	case StatusSuccess:
+		return "\033[32m🟢\033[0m" // Green
+	case StatusFailed:
+		return "\033[31m🔴\033[0m" // Red
+	default:
+		return "⚪"
+	}
+}
+
+func printSummary(results map[string]*ClientResult) {
+	var pending, running, success, failed int
+
+	for _, result := range results {
+		switch result.Status {
+		case StatusPending:
+			pending++
+		case StatusRunning:
+			running++
+		case StatusSuccess:
+			success++
+		case StatusFailed:
+			failed++
+		}
+	}
+
+	fmt.Printf("\nFinal Summary: %d total, %d success, %d failed, %d pending, %d running\n",
+		len(results), success, failed, pending, running)
+
+	// Print failed clients with errors
+	if failed > 0 {
+		fmt.Println("\nFailed clients:")
+		for _, result := range results {
+			if result.Status == StatusFailed {
+				fmt.Printf("  %s: %v\n", result.DoraInfo.ClientName, result.Error)
+			}
+		}
+	}
+
+	// Print successful clients
+	if success > 0 {
+		fmt.Println("\nSuccessful clients:")
+		for _, result := range results {
+			if result.Status == StatusSuccess {
+				fmt.Printf("  %s: completed successfully\n", result.DoraInfo.ClientName)
+			}
+		}
+	}
+}
+
+func configureGlobalLogger(logDir string) error {
+	// logrus to keep the logs in the same folder
+	if err := ensureLogPath(logDir); err != nil {
+		return fmt.Errorf("unable to create log-folder at %s - %w", logDir, err)
+	}
+
+	mainLogsFile := logDir + "/main.logs"
+	f, err := os.OpenFile(mainLogsFile, os.O_CREATE|os.O_WRONLY, 0755)
+	if err != nil {
+		return err
+	}
+
+	// init logrus to keep logs in the previously create folder
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetOutput(f)
+	logrus.SetLevel(ParseLogLevel(rootConfig.LogLevel))
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v3"
 )
@@ -118,21 +117,4 @@ func main() {
 		os.Exit(1)
 	}
 	os.Exit(0)
-}
-
-func ParseLogLevel(level string) logrus.Level {
-	switch level {
-	case "trace":
-		return logrus.TraceLevel
-	case "debug":
-		return logrus.DebugLevel
-	case "info":
-		return logrus.InfoLevel
-	case "warn":
-		return logrus.WarnLevel
-	case "error":
-		return logrus.ErrorLevel
-	default:
-		return logrus.InfoLevel
-	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,11 +6,13 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v3"
 )
 
 var rootConfig = struct {
+	LogLevel                string
 	Libp2pHost              string
 	Libp2pPort              int
 	BeaconAPIendpoint       string
@@ -20,6 +22,7 @@ var rootConfig = struct {
 	InitTimeout             time.Duration
 	WaitForFulu             bool
 }{
+	LogLevel:                "info",
 	Libp2pHost:              "127.0.0.1",
 	Libp2pPort:              9013,
 	BeaconAPIendpoint:       "http://127.0.0.1:5052/",
@@ -38,10 +41,17 @@ var rootCmd = &cli.Command{
 	Commands: []*cli.Command{
 		cmdScan,
 		cmdMonitor,
+		cmdPlaytime,
 	},
 }
 
 var rootFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:        "log.level",
+		Usage:       "Level of the logs",
+		Value:       rootConfig.LogLevel,
+		Destination: &rootConfig.LogLevel,
+	},
 	&cli.StringFlag{
 		Name:        "libp2p.host",
 		Usage:       "IP for the Libp2p host",
@@ -108,4 +118,21 @@ func main() {
 		os.Exit(1)
 	}
 	os.Exit(0)
+}
+
+func ParseLogLevel(level string) logrus.Level {
+	switch level {
+	case "trace":
+		return logrus.TraceLevel
+	case "debug":
+		return logrus.DebugLevel
+	case "info":
+		return logrus.InfoLevel
+	case "warn":
+		return logrus.WarnLevel
+	case "error":
+		return logrus.ErrorLevel
+	default:
+		return logrus.InfoLevel
+	}
 }

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -81,8 +81,7 @@ func scanAction(ctx context.Context, cmd *cli.Command) error {
 		"slot-range-slots":   scanConfig.SlotCustomRange,
 	}).Info("running das-guardian")
 
-	logger := log.WithFields(log.Fields{})
-
+	logger := log.New()
 	ethConfig := &dasguardian.DasGuardianConfig{
 		Logger:                  logger,
 		Libp2pHost:              rootConfig.Libp2pHost,

--- a/devnet_scanner.go
+++ b/devnet_scanner.go
@@ -201,7 +201,7 @@ func (s *DevnetScanner) scanClients(ctx context.Context) ([]ClientResult, error)
 		}()
 	}
 
-	var i = 0
+	i := 0
 orchester:
 	for clName, clientM := range s.ClClients {
 		select {
@@ -228,7 +228,7 @@ func (s *DevnetScanner) configureLoggers(logDir string) error {
 
 func (s *DevnetScanner) newLogger(fPath string) (*logrus.Logger, *os.File, error) {
 	log := logrus.New()
-	f, err := os.OpenFile(s.cfg.LogDir+"/"+fPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0755)
+	f, err := os.OpenFile(s.cfg.LogDir+"/"+fPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o755)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/devnet_scanner.go
+++ b/devnet_scanner.go
@@ -1,0 +1,313 @@
+package dasguardian
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/pkg/errors"
+	"github.com/probe-lab/eth-das-guardian/dora"
+	"github.com/sirupsen/logrus"
+)
+
+// ClientResult holds the result of processing a client
+type ClientResult struct {
+	ClientName string
+	Status     ClientStatus
+	Error      error
+}
+
+type DevnetScannerConfig struct {
+	// log config
+	LogLevel  logrus.Level
+	LogFormat logrus.Formatter
+	LogDir    string
+
+	// variables
+	Parallelism       int32
+	DoraApiEndpoint   string
+	BeaconApiEndpoint string
+	DryScan           bool
+}
+
+type DevnetScanner struct {
+	// config
+	cfg      DevnetScannerConfig
+	mainLog  *logrus.Logger
+	mainLogF *os.File
+
+	// Dora API
+	DoraApi *dora.Client
+
+	// client data
+	ClClients map[string]*clientMonitor
+}
+
+func NewDevnetScanner(cfg DevnetScannerConfig) (*DevnetScanner, error) {
+	return &DevnetScanner{
+		cfg:       cfg,
+		ClClients: make(map[string]*clientMonitor),
+	}, nil
+}
+
+func (s *DevnetScanner) Start(ctx context.Context) error {
+	if err := s.init(ctx); err != nil {
+		return err
+	}
+	defer s.close()
+
+endlessLoop:
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			results, err := s.scanClients(ctx)
+			if err != nil {
+				return err
+			}
+			displayGrid(results)
+			if s.cfg.DryScan {
+				break endlessLoop
+			}
+		}
+	}
+	return nil
+}
+
+func (s *DevnetScanner) close() error {
+	// close the file descriptors
+	// TODO: iter through each of the indv loggers per client
+	err := s.mainLogF.Close()
+	if err != nil {
+		logrus.Error(errors.Wrap(err, "closing main logger"))
+	}
+	for _, clMonitor := range s.ClClients {
+		if err := clMonitor.loggerF.Close(); err != nil {
+			logrus.Error(errors.Wrap(err, "closing main logger for "+clMonitor.nodeInfo.ClientName))
+		}
+	}
+	return nil
+}
+
+func (s *DevnetScanner) init(ctx context.Context) error {
+	// configure main logger
+	err := s.configureLoggers(s.cfg.LogDir)
+	if err != nil {
+		return errors.Wrap(err, "configuring the loggers")
+	}
+	s.mainLog, s.mainLogF, err = s.newLogger("main.logs")
+	if err != nil {
+		return errors.Wrap(err, "creating main logger")
+	}
+
+	// create new API client for Dora
+	s.DoraApi, err = dora.NewClient(dora.ClientConfig{
+		Endpoint:     s.cfg.DoraApiEndpoint,
+		QueryTimeout: 10 * time.Second, // TODO: hardcoded
+		Logger:       s.mainLog,
+	})
+	if err != nil {
+		return err
+	}
+
+	// get the whole list of clients from the Dora API
+	consensusClients, err := s.DoraApi.GetConsensusClients(ctx)
+	if err != nil {
+		return err
+	}
+	if consensusClients.Count == 0 {
+		logrus.Error("No clients found from Dora API")
+		return nil
+	}
+
+	// Initialize client results
+	for _, client := range consensusClients.Clients {
+		clLogger, logF, err := s.newLogger(fmt.Sprintf("%s.logs", client.ClientName))
+		if err != nil {
+			return err
+		}
+
+		guardianCfg := &DasGuardianConfig{
+			Logger:                  clLogger,
+			Libp2pHost:              "127.0.0.1",
+			Libp2pPort:              9020,
+			ConnectionRetries:       3,
+			ConnectionTimeout:       10 * time.Second,
+			BeaconAPIendpoint:       s.cfg.BeaconApiEndpoint,
+			BeaconAPIcustomClClient: "",
+			WaitForFulu:             false,
+			InitTimeout:             20 * time.Second,
+		}
+		clClientMonitor, err := newClientMonitor(ctx, guardianCfg, logF, client)
+		if err != nil {
+			return err
+		}
+		s.ClClients[client.ClientName] = clClientMonitor
+		s.mainLog.WithFields(logrus.Fields{
+			"client-name": client.ClientName,
+			"version":     client.Version,
+		}).Debug("new consensus node")
+	}
+	s.mainLog.WithFields(logrus.Fields{
+		"clients": len(s.ClClients),
+	}).Info("reply from Dora to indentify participants")
+	return nil
+}
+
+func ensureLogPath(path string) error {
+	_, err := os.Stat(path)
+	if err != nil {
+		// only create the folder if it doesn't exists
+		return os.Mkdir(path, 0o755)
+	} else {
+		return err
+	}
+}
+
+func (s *DevnetScanner) scanClients(ctx context.Context) ([]ClientResult, error) {
+	var m sync.Mutex
+	numClients := len(s.ClClients)
+	clientResults := make([]ClientResult, 0, numClients)
+	clientC := make(chan string, s.cfg.Parallelism)
+	var wg sync.WaitGroup
+
+	// spawn the consumers
+	for i := int32(0); i < s.cfg.Parallelism; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case clName, ok := <-clientC:
+					if !ok {
+						return
+					}
+					clientMonitor, ok := s.ClClients[clName]
+					if !ok {
+						s.mainLog.Panicf("couldn't finde a client-monitor ready item for %s", clName)
+					}
+					res := clientMonitor.scanClient(ctx, 5) // TODO: hardcoded
+					m.Lock()
+					clientResults = append(clientResults, res)
+					m.Unlock()
+				}
+			}
+		}()
+	}
+
+	var i = 0
+orchester:
+	for clName, clientM := range s.ClClients {
+		select {
+		case clientC <- clName:
+			i++
+			s.mainLog.WithFields(logrus.Fields{
+				"client-name": clName,
+				"version":     clientM.nodeInfo.Version,
+				"indes":       fmt.Sprintf("node: %d/%d", i, numClients),
+			}).Info("scanning node...")
+			// pass
+		case <-ctx.Done():
+			break orchester
+		}
+	}
+	close(clientC)
+	wg.Wait()
+	return clientResults, nil
+}
+
+func (s *DevnetScanner) configureLoggers(logDir string) error {
+	return ensureLogPath(logDir)
+}
+
+func (s *DevnetScanner) newLogger(fPath string) (*logrus.Logger, *os.File, error) {
+	log := logrus.New()
+	f, err := os.OpenFile(s.cfg.LogDir+"/"+fPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0755)
+	if err != nil {
+		return nil, nil, err
+	}
+	log.SetFormatter(&logrus.JSONFormatter{})
+	log.SetOutput(f)
+	log.SetLevel(s.cfg.LogLevel)
+	return log, f, nil
+}
+
+type clientMonitor struct {
+	// main
+	guardianCfg *DasGuardianConfig
+	logger      *logrus.Logger
+	loggerF     *os.File
+
+	// client info
+	nodeInfo dora.ConsensusClientNodeInfo
+	ethNode  *enode.Node
+
+	// results
+	lastResult ClientResult
+}
+
+func newClientMonitor(ctx context.Context, guardianCfg *DasGuardianConfig, logF *os.File, nodeInfo dora.ConsensusClientNodeInfo) (*clientMonitor, error) {
+	ethNode, err := ParseNode(nodeInfo.ENR)
+	if err != nil {
+		return nil, err
+	}
+	return &clientMonitor{
+		// main
+		guardianCfg: guardianCfg,
+		logger:      guardianCfg.Logger,
+		loggerF:     logF,
+		// info
+		nodeInfo: nodeInfo,
+		ethNode:  ethNode,
+		// results
+		lastResult: ClientResult{},
+	}, nil
+}
+
+func (m *clientMonitor) scanClient(ctx context.Context, slots int32) ClientResult {
+	result := ClientResult{
+		ClientName: m.nodeInfo.ClientName,
+		Status:     StatusRunning,
+		Error:      nil,
+	}
+	// create a new DASGuardian instance on each scan
+	guardian, err := NewDASGuardian(ctx, m.guardianCfg)
+	if err != nil {
+		result.Status = StatusFailed
+		result.Error = err
+		return result
+	}
+	defer guardian.Close()
+	scanResult, err := guardian.Scan(ctx, m.ethNode, WithRandomAvailableSlots(slots))
+	if err != nil {
+		result.Status = StatusFailed
+		result.Error = err
+		return result
+	}
+	scanResult.EvalResult.LogVisualization(m.logger)
+
+	if scanResult.EvalResult.Error != nil {
+		result.Status = StatusFailed
+		result.Error = err
+		return result
+	}
+
+	// make sure that the resutls are correct
+	// check the number of columns
+	for i, validSlot := range scanResult.EvalResult.ValidSlot {
+		if !validSlot {
+			result.Status = StatusFailed
+			result.Error = fmt.Errorf("slot %d was invalid", scanResult.EvalResult.Slots[i])
+			return result
+		}
+	}
+	result.Status = StatusSuccess
+	result.Error = nil
+	return result
+}

--- a/dora/client.go
+++ b/dora/client.go
@@ -1,0 +1,145 @@
+package dora
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type ClientConfig struct {
+	Endpoint     string
+	StateTimeout time.Duration
+	QueryTimeout time.Duration
+	Logger       log.FieldLogger
+}
+
+type Client struct {
+	cfg    ClientConfig
+	base   *url.URL
+	client *http.Client
+}
+
+func NewClient(cfg ClientConfig) (*Client, error) {
+	// http client for the communication
+	httpCli := &http.Client{
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   cfg.QueryTimeout,
+				KeepAlive: 40 * time.Second,
+			}).DialContext,
+			IdleConnTimeout: 600 * time.Second,
+		},
+	}
+
+	urlBase, err := url.Parse(cfg.Endpoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "compose API's base URL")
+	}
+
+	cli := &Client{
+		cfg:    cfg,
+		base:   urlBase,
+		client: httpCli,
+	}
+
+	return cli, nil
+}
+
+func (c *Client) CheckConnection(ctx context.Context) error {
+	latestEpoch, err := c.GetEpochV1(ctx, "latest")
+	if err != nil {
+		return errors.Wrap(err, "testing connectivity")
+	}
+	log.WithFields(log.Fields{
+		"latest-epoch": latestEpoch,
+	}).Info("successfull connection to the dora's api")
+	return nil
+}
+
+func (c *Client) get(
+	ctx context.Context,
+	timeout time.Duration,
+	endpoint string,
+	query string,
+) ([]byte, error) {
+	var respBody []byte
+
+	// set deadline
+	opCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	callURL := composeCallURL(c.base, endpoint, query)
+	req, err := http.NewRequestWithContext(opCtx, http.MethodGet, callURL.String(), nil)
+	if err != nil {
+		return []byte{}, errors.Wrap(err, "unable to compose call URL")
+	}
+
+	l := c.cfg.Logger.WithFields(log.Fields{
+		"url":    callURL,
+		"method": req.Method,
+	})
+	l.Info("requesting beacon API")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		l.WithError(err).Warn("error requesting beacon API")
+		return respBody, errors.Wrap(err, fmt.Sprintf("unable to request URL %s", callURL.String()))
+	}
+	if resp == nil {
+		err := errors.New("got empty response from the API")
+		l.WithError(err).Warn("error requesting beacon API")
+		return respBody, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		l.WithFields(log.Fields{
+			"status_code": resp.StatusCode,
+			"status":      resp.Status,
+		}).Warn("beacon API returned non-success status code")
+
+		// Read the error response body for better error messages
+		errorBody, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return respBody, fmt.Errorf("unable to read api-response %s", err.Error())
+		}
+		return respBody, fmt.Errorf("beacon API request failed %s - %s", resp.Status, string(errorBody))
+	}
+
+	respBody, err = io.ReadAll(resp.Body)
+	if err != nil {
+		l.WithError(err).Warn("failed to read response body")
+		return respBody, errors.Wrap(err, "reading response body")
+	}
+
+	if len(respBody) > 1024 {
+		l.Infof("successful beacon API response: [omitted due to length %d]", len(respBody))
+	} else {
+		l.Infof("successful beacon API response: %s", respBody)
+	}
+
+	return respBody, nil
+}
+
+func composeCallURL(base *url.URL, endpoint, query string) *url.URL {
+	callURL := *base
+	callURL.Path += endpoint
+	if callURL.RawQuery == "" {
+		callURL.RawQuery = query
+	} else if query != "" {
+		callURL.RawQuery = fmt.Sprintf("%s&%s", callURL.RawQuery, query)
+	}
+
+	return &callURL
+}
+
+func (c *Client) Close() error {
+	c.client.CloseIdleConnections()
+	return nil
+}

--- a/dora/client.go
+++ b/dora/client.go
@@ -15,7 +15,6 @@ import (
 
 type ClientConfig struct {
 	Endpoint     string
-	StateTimeout time.Duration
 	QueryTimeout time.Duration
 	Logger       log.FieldLogger
 }

--- a/dora/client_test.go
+++ b/dora/client_test.go
@@ -1,0 +1,58 @@
+package dora
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	DoraTestAPIEndpoint = "https://dora.fusaka-devnet-2.ethpandaops.io/api/"
+	StateTimeout        = 30 * time.Second
+	QueryTimeout        = 10 * time.Second
+)
+
+// API connection
+func TestDoraApiClient(t *testing.T) {
+	httpCli, testMainCtx, cancel := genTestAPICli(t)
+	defer cancel()
+
+	err := httpCli.CheckConnection(testMainCtx)
+	require.NoError(t, err)
+}
+
+// API endpoints
+func TestDoraApiClient_GetEpoch(t *testing.T) {
+	httpCli, testMainCtx, cancel := genTestAPICli(t)
+	defer cancel()
+
+	_, err := httpCli.GetEpochV1(testMainCtx, "latest")
+	require.NoError(t, err)
+}
+
+func TestDoraApiClient_GetNetworkConsensusNodes(t *testing.T) {
+	httpCli, testMainCtx, cancel := genTestAPICli(t)
+	defer cancel()
+
+	_, err := httpCli.GetConsensusClients(testMainCtx)
+	require.NoError(t, err)
+}
+
+// generics
+func genTestAPICli(t *testing.T) (*Client, context.Context, context.CancelFunc) {
+	testMainCtx, cancel := context.WithCancel(context.Background())
+
+	cfg := ClientConfig{
+		Endpoint:     DoraTestAPIEndpoint,
+		StateTimeout: StateTimeout,
+		QueryTimeout: QueryTimeout,
+		Logger:       log.WithFields(log.Fields{}),
+	}
+
+	httpCli, err := NewClient(cfg)
+	require.NoError(t, err)
+	return httpCli, testMainCtx, cancel
+}

--- a/dora/client_test.go
+++ b/dora/client_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	DoraTestAPIEndpoint = "https://dora.fusaka-devnet-2.ethpandaops.io/api/"
+	DoraTestAPIEndpoint = "https://dora.fusaka-devnet-3.ethpandaops.io/api/"
 	StateTimeout        = 30 * time.Second
 	QueryTimeout        = 10 * time.Second
 )

--- a/dora/client_test.go
+++ b/dora/client_test.go
@@ -47,7 +47,6 @@ func genTestAPICli(t *testing.T) (*Client, context.Context, context.CancelFunc) 
 
 	cfg := ClientConfig{
 		Endpoint:     DoraTestAPIEndpoint,
-		StateTimeout: StateTimeout,
 		QueryTimeout: QueryTimeout,
 		Logger:       log.WithFields(log.Fields{}),
 	}

--- a/dora/epoch.go
+++ b/dora/epoch.go
@@ -1,0 +1,51 @@
+package dora
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+var EpochV1Base = "v1/epoch/%s"
+
+type EpochResponseV1 struct {
+	Epoch                   uint64 `json:"epoch"`
+	Ts                      uint64 `json:"ts"`
+	AttestationsCount       uint64 `json:"attestationscount"`
+	AttesterSlashingsCount  uint64 `json:"attesterslashingscount"`
+	AverageValidatorBalance uint64 `json:"averagevalidatorbalance"`
+	BlocksCount             uint64 `json:"blockscount"`
+	DepositsCount           uint64 `json:"depositscount"`
+	EligibleEther           uint64 `json:"eligibleether"`
+	Finalized               bool   `json:"finalized"`
+	GlobalParticipationRate uint64 `json:"globalparticipationrate"`
+	MissedBlocks            uint64 `json:"missedblocks"`
+	OrphanedBlocks          uint64 `json:"orphanedblocks"`
+	ProposedBlocks          uint64 `json:"proposedblocks"`
+	ProposerSlashingsCount  uint64 `json:"proposerslashingscount"`
+	ScheduledBlocks         uint64 `json:"scheduledblocks"`
+	TotalValidatorBalance   uint64 `json:"totalvalidatorbalance"`
+	ValidatorsCount         uint64 `json:"validatorscount"`
+	VoluntaryExitsCount     uint64 `json:"voluntaryexitscount"`
+	VotedEther              uint64 `json:"votedether"`
+	RewardsExported         uint64 `json:"rewards_exported"`
+	WithdrawalCount         uint64 `json:"withdrawalcount"`
+}
+
+func (c *Client) GetEpochV1(ctx context.Context, epochReq string) (*EpochResponseV1, error) {
+	epoch := &EpochResponseV1{}
+	if epochReq == "" {
+		epochReq = "latest"
+	}
+	resp, err := c.get(ctx, c.cfg.QueryTimeout, fmt.Sprintf(EpochV1Base, epochReq), "")
+	if err != nil {
+		return nil, errors.Wrap(err, "requesting network's ")
+	}
+	err = json.Unmarshal(resp, &epoch)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshaling beacon-block from http request")
+	}
+	return epoch, nil
+}

--- a/dora/list_nodes.go
+++ b/dora/list_nodes.go
@@ -1,0 +1,58 @@
+package dora
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+var NetworkConsensusClientsBase = "v1/clients/consensus"
+
+// ConsensusClientNodeInfo represents the response structure for consensus client node info
+type ConsensusClientNodeInfo struct {
+	ClientName         string                   `json:"client_name"`
+	ClientType         string                   `json:"client_type"`
+	Version            string                   `json:"version"`
+	PeerID             string                   `json:"peer_id"`
+	NodeID             string                   `json:"node_id"`
+	ENR                string                   `json:"enr"`
+	HeadSlot           uint64                   `json:"head_slot"`
+	HeadRoot           string                   `json:"head_root"`
+	Status             string                   `json:"status"`
+	PeerCount          uint32                   `json:"peer_count"`
+	PeersInbound       uint32                   `json:"peers_inbound"`
+	PeersOutbound      uint32                   `json:"peers_outbound"`
+	LastRefresh        string                   `json:"last_refresh"`
+	LastError          string                   `json:"last_error,omitempty"`
+	SupportsDataColumn bool                     `json:"supports_data_column"`
+	ColumnIndexes      []uint64                 `json:"column_indexes,omitempty"`
+	Metadata           *ConsensusClientMetadata `json:"metadata,omitempty"`
+}
+
+// ConsensusClientMetadata represents the metadata from the node identity
+type ConsensusClientMetadata struct {
+	Attnets           string `json:"attnets,omitempty"`
+	Syncnets          string `json:"syncnets,omitempty"`
+	SeqNumber         string `json:"seq_number,omitempty"`
+	CustodyGroupCount string `json:"custody_group_count,omitempty"` // MetadataV3 field for Fulu
+}
+
+// ConsensusClientsResponse represents the full  response
+type ConsensusClientsResponse struct {
+	Clients []ConsensusClientNodeInfo `json:"clients"`
+	Count   int                       `json:"count"`
+}
+
+func (c *Client) GetConsensusClients(ctx context.Context) (*ConsensusClientsResponse, error) {
+	consensusNodes := &ConsensusClientsResponse{}
+	resp, err := c.get(ctx, c.cfg.QueryTimeout, NetworkConsensusClientsBase, "")
+	if err != nil {
+		return nil, errors.Wrap(err, "requesting network's consensus clients")
+	}
+	err = json.Unmarshal(resp, &consensusNodes)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshaling beacon-block from http request")
+	}
+	return consensusNodes, nil
+}

--- a/guardian.go
+++ b/guardian.go
@@ -65,7 +65,7 @@ const (
 )
 
 type DasGuardianConfig struct {
-	Logger                  log.FieldLogger
+	Logger                  *log.Logger
 	Libp2pHost              string
 	Libp2pPort              int
 	ConnectionRetries       int
@@ -301,13 +301,13 @@ func (g *DasGuardian) Close() error {
 	if !g.isHostInit.Load() {
 		return nil
 	}
-	log.Info("terminating libp2p host...")
+	g.cfg.Logger.Info("terminating libp2p host...")
 	g.isHostInit.Store(false)
 	return g.host.Close()
 }
 
 func (g *DasGuardian) disconnectPeer(pid peer.ID) error {
-	log.Infof("disconnecting %s", pid.String())
+	g.cfg.Logger.Infof("disconnecting %s", pid.String())
 	return g.host.Network().ClosePeer(pid)
 }
 

--- a/guardian_test.go
+++ b/guardian_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	testBeaconAPI = "https://beacon.fusaka-devnet-2.ethpandaops.io/"
+	testBeaconAPI = "https://beacon.fusaka-devnet-3.ethpandaops.io/"
 )
 
 func Test_DASGuardianClientInterop(t *testing.T) {

--- a/result_eval.go
+++ b/result_eval.go
@@ -84,21 +84,28 @@ func evaluateColumnResponses(
 		}
 
 		// check if the commitments match
-		for c, dataCol := range cols[s] {
+		for c, _ := range columnIdxs {
 			blockKzgCommitments, _ := bBlocks[s].BlobKZGCommitments()
-			validCom := 0
-			for _, colCom := range dataCol.KzgCommitments {
-			kzgCheckLoop:
-				for _, kzgCom := range blockKzgCommitments {
-					if matchingBytes(colCom[:], kzgCom[:]) {
-						validCom++
-						break kzgCheckLoop
+			if c >= len(cols[s]) {
+				validKzg[c] = fmt.Sprintf("0/%d", len(blockKzgCommitments))
+				downloaded[c] = fmt.Sprintf("0/%d", len(blockKzgCommitments))
+				validColumn[c] = false
+			} else {
+				dataCol := cols[s]
+				validCom := 0
+				for _, colCom := range dataCol[c].KzgCommitments {
+				kzgCheckLoop:
+					for _, kzgCom := range blockKzgCommitments {
+						if matchingBytes(colCom[:], kzgCom[:]) {
+							validCom++
+							break kzgCheckLoop
+						}
 					}
 				}
+				validKzg[c] = fmt.Sprintf("%d/%d", validCom, len(blockKzgCommitments))
+				downloaded[c] = fmt.Sprintf("%d/%d", len(dataCol[c].KzgCommitments), len(blockKzgCommitments))
+				validColumn[c] = (len(blockKzgCommitments) == validCom)
 			}
-			validKzg[c] = fmt.Sprintf("%d/%d", validCom, len(blockKzgCommitments))
-			downloaded[c] = fmt.Sprintf("%d/%d", len(dataCol.KzgCommitments), len(blockKzgCommitments))
-			validColumn[c] = (len(blockKzgCommitments) == validCom)
 		}
 	}
 	// compose the table
@@ -119,7 +126,7 @@ func matchingBytes(org, to []byte) (equal bool) {
 	return true
 }
 
-func (res *DASEvaluationResult) LogVisualization(logger log.FieldLogger) error {
+func (res *DASEvaluationResult) LogVisualization(logger *log.Logger) error {
 	if res.Slots == nil {
 		return nil
 	}

--- a/result_eval.go
+++ b/result_eval.go
@@ -84,7 +84,7 @@ func evaluateColumnResponses(
 		}
 
 		// check if the commitments match
-		for c, _ := range columnIdxs {
+		for c := range columnIdxs {
 			blockKzgCommitments, _ := bBlocks[s].BlobKZGCommitments()
 			if c >= len(cols[s]) {
 				validKzg[c] = fmt.Sprintf("0/%d", len(blockKzgCommitments))

--- a/slot_selector.go
+++ b/slot_selector.go
@@ -6,6 +6,7 @@ import (
 	mrand "math/rand"
 
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/probe-lab/eth-das-guardian/api"
 	"github.com/sirupsen/logrus"
 )
 
@@ -211,7 +212,12 @@ func GenerateRandomSlots(ctx context.Context, beaconApi BeaconAPI, n int32, valF
 
 			bblock, err := beaconApi.GetBeaconBlock(ctx, slot)
 			if err != nil {
-				return nil, fmt.Errorf("retrieving slot %d - %v", slot, err)
+				switch err {
+				case api.ErrBlockNotFound:
+					continue
+				default:
+					return nil, fmt.Errorf("retrieving slot %d - %v", slot, err)
+				}
 			}
 
 			if valFn(bblock) {
@@ -241,7 +247,7 @@ func GenerateRandomSlots(ctx context.Context, beaconApi BeaconAPI, n int32, valF
 	logrus.WithFields(logrus.Fields{
 		"total-requested": len(checkedSlots),
 		"valid-ones":      len(sampSlots),
-	}).Info("generated random slots for sampling")
+	}).Debug("generated random slots for sampling")
 
 	return sampSlots, nil
 }

--- a/tui.go
+++ b/tui.go
@@ -20,9 +20,9 @@ func displayGrid(results []ClientResult) {
 	fmt.Print("\033[2J\033[H")
 
 	fmt.Println("Consensus Clients Status:", time.Now().Format(time.RFC850))
-	fmt.Println("===============================================")
+	fmt.Println("===========================================================")
 
-	const colWidth = 40
+	const colWidth = 50
 	const cols = 4
 
 	for i := 0; i < len(results); i += cols {
@@ -30,8 +30,8 @@ func displayGrid(results []ClientResult) {
 			client := results[i+j]
 			status := getStatusDisplay(client.Status)
 			clientName := client.ClientName
-			if len(clientName) > 15 {
-				clientName = clientName[:15] + "..."
+			if len(clientName) > 25 {
+				clientName = clientName[:25] + "..."
 			}
 			fmt.Printf(" %-*s", colWidth, fmt.Sprintf("%s %s", status, clientName))
 		}

--- a/tui.go
+++ b/tui.go
@@ -1,0 +1,141 @@
+package dasguardian
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ClientStatus represents the execution status of a client
+type ClientStatus int
+
+const (
+	StatusPending ClientStatus = iota
+	StatusRunning
+	StatusSuccess
+	StatusFailed
+)
+
+var (
+	// TODO: move this to a separate module
+	gridMutex sync.RWMutex
+	stopGrid  chan struct{}
+)
+
+func startLiveGridUpdates(results []ClientResult) {
+	ticker := time.NewTicker(500 * time.Millisecond) // Update every 500ms
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			displayGrid(results)
+		case <-stopGrid:
+			return
+		}
+	}
+}
+
+func displayGrid(results []ClientResult) {
+	gridMutex.RLock()
+	defer gridMutex.RUnlock()
+
+	// Clear screen and move cursor to top
+	fmt.Print("\033[2J\033[H")
+
+	fmt.Println("Consensus Clients Status:", time.Now().Format(time.RFC850))
+	fmt.Println("===============================================")
+
+	const colWidth = 40
+	const cols = 4
+
+	for i := 0; i < len(results); i += cols {
+		for j := 0; j < cols && i+j < len(results); j++ {
+			client := results[i+j]
+			status := getStatusDisplay(client.Status)
+			clientName := client.ClientName
+			if len(clientName) > 15 {
+				clientName = clientName[:15] + "..."
+			}
+			fmt.Printf(" %-*s", colWidth, fmt.Sprintf("%s %s", status, clientName))
+		}
+		fmt.Println()
+	}
+
+	fmt.Println()
+	fmt.Println("Legend: 🟡 Running, 🟢 Success, 🔴 Failed, ⚪ Pending")
+
+	// Show current counts
+	var pending, running, success, failed int
+	for _, result := range results {
+		switch result.Status {
+		case StatusPending:
+			pending++
+		case StatusRunning:
+			running++
+		case StatusSuccess:
+			success++
+		case StatusFailed:
+			failed++
+		}
+	}
+
+	fmt.Printf("Status: %d pending, %d running, %d success, %d failed\n",
+		pending, running, success, failed)
+	fmt.Println()
+}
+
+func getStatusDisplay(status ClientStatus) string {
+	switch status {
+	case StatusPending:
+		return "⚪"
+	case StatusRunning:
+		return "\033[33m🟡\033[0m" // Yellow
+	case StatusSuccess:
+		return "\033[32m🟢\033[0m" // Green
+	case StatusFailed:
+		return "\033[31m🔴\033[0m" // Red
+	default:
+		return "⚪"
+	}
+}
+
+func printSummary(results []ClientResult) {
+	var pending, running, success, failed int
+
+	for _, result := range results {
+		switch result.Status {
+		case StatusPending:
+			pending++
+		case StatusRunning:
+			running++
+		case StatusSuccess:
+			success++
+		case StatusFailed:
+			failed++
+		}
+	}
+
+	fmt.Printf("\nFinal Summary: %d total, %d success, %d failed, %d pending, %d running\n",
+		len(results), success, failed, pending, running)
+
+	// Print failed clients with errors
+	if failed > 0 {
+		fmt.Println("\nFailed clients:")
+		for _, result := range results {
+			if result.Status == StatusFailed {
+				fmt.Printf("  %s: %v\n", result.ClientName, result.Error)
+			}
+		}
+	}
+
+	// Print successful clients
+	if success > 0 {
+		fmt.Println("\nSuccessful clients:")
+		for _, result := range results {
+			if result.Status == StatusSuccess {
+				fmt.Printf("  %s: completed successfully\n", result.ClientName)
+			}
+		}
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"
+	"github.com/sirupsen/logrus"
 )
 
 func ParseNode(rawEnr string) (*enode.Node, error) {
@@ -91,4 +92,21 @@ func hash(data []byte) [32]byte {
 
 func isNill(i any) bool {
 	return i == nil
+}
+
+func ParseLogLevel(level string) logrus.Level {
+	switch level {
+	case "trace":
+		return logrus.TraceLevel
+	case "debug":
+		return logrus.DebugLevel
+	case "info":
+		return logrus.InfoLevel
+	case "warn":
+		return logrus.WarnLevel
+	case "error":
+		return logrus.ErrorLevel
+	default:
+		return logrus.InfoLevel
+	}
 }


### PR DESCRIPTION
# Description
The current tool can `scan` and `monitor` nodes from the CLI tool. However, it requires some extra logic or bash scripts to scan the whole Ethereum devnet. 

This PR adds support for the Dora API endpoints, which allow us to discover all online nodes in the devnet. Therefore, makes the scan of the whole network easy.

The PR includes:
- [x] support for the Dora API
- [x] new `playtime` command
- [x] separate `devnet-scanning` logic (splitting logs on a separate log-file per peer for debugging)
- [x] appealing visualisation for the devnet node scanning

<img width="1049" height="581" alt="image" src="https://github.com/user-attachments/assets/ea1f1a35-c6e8-42d0-9a06-df94e602bbe8" />

CC:  @raulk and the #35 issue  
 