### PR TITLE
Patch broken result evaluation with no downloaded columns

### DIFF
--- a/guardian.go
+++ b/guardian.go
@@ -306,8 +306,18 @@ func (g *DasGuardian) Close() error {
 	return g.host.Close()
 }
 
-func (g *DasGuardian) disconnectPeer(pid peer.ID) error {
+func (g *DasGuardian) disconnectPeer(ctx context.Context, pid peer.ID) error {
 	g.cfg.Logger.Infof("disconnecting %s", pid.String())
+
+	// make goodbye before disconnecting
+	gbCtx, gbCancel := context.WithTimeout(ctx, g.cfg.ConnectionTimeout)
+	defer gbCancel()
+	err := g.rpcServ.GoodBye(gbCtx, pid, GoodbyeCodeClientShutdown)
+	if err != nil {
+		log.Errorf("saying goodbye to peer %s - %v", pid.String(), err)
+		return err
+	}
+
 	return g.host.Network().ClosePeer(pid)
 }
 
@@ -449,7 +459,7 @@ func (g *DasGuardian) scanElectra(ctx context.Context, peerInfo *PeerInfo, slotS
 	prettyLogrusFields(g.cfg.Logger, "beacon status...", statusLogs)
 	prettyLogrusFields(g.cfg.Logger, "beacon metadata...", metadataLogs)
 
-	if err := g.disconnectPeer(peerInfo.AddrInfo.ID); err != nil {
+	if err := g.disconnectPeer(ctx, peerInfo.AddrInfo.ID); err != nil {
 		log.Errorf("unable to disconnect from remote peer %s - %s", peerInfo.AddrInfo.ID.String(), err.Error())
 	}
 	return scanResult, nil
@@ -537,7 +547,7 @@ func (g *DasGuardian) scanFulu(ctx context.Context, peerInfo *PeerInfo, slotSele
 		scanResult.EvalResult = evalResult
 	}
 
-	if err := g.disconnectPeer(peerInfo.AddrInfo.ID); err != nil {
+	if err := g.disconnectPeer(ctx, peerInfo.AddrInfo.ID); err != nil {
 		log.Errorf("unable to disconnect from remote peer %s - %s", peerInfo.AddrInfo.ID.String(), err.Error())
 	}
 

--- a/guardian.go
+++ b/guardian.go
@@ -314,7 +314,6 @@ func (g *DasGuardian) disconnectPeer(ctx context.Context, pid peer.ID) error {
 	defer gbCancel()
 	err := g.rpcServ.GoodBye(gbCtx, pid, GoodbyeCodeClientShutdown)
 	if err != nil {
-		log.Errorf("saying goodbye to peer %s - %v", pid.String(), err)
 		return err
 	}
 

--- a/result_eval.go
+++ b/result_eval.go
@@ -181,7 +181,7 @@ func (res *DASEvaluationResult) LogVisualization(logger *log.Logger) error {
 		}
 		for colIdx, downloadedResult := range res.RangeResult[s].DownloadResult {
 			// log RangeResults
-			if res.RangeResult[colIdx].ValidSlot {
+			if res.RangeResult[s].ValidSlot {
 				logger.Infof(
 					"range req: slot(%d) col(%d) - data-cols(%s) valid-kzgs(%s)",
 					slot,
@@ -199,7 +199,7 @@ func (res *DASEvaluationResult) LogVisualization(logger *log.Logger) error {
 				)
 			}
 			// log RootResults
-			if res.RootResult[colIdx].ValidSlot {
+			if res.RootResult[s].ValidSlot {
 				logger.Infof(
 					"root req: slot(%d) col(%d) - data-cols(%s) valid-kzgs(%s)",
 					slot,

--- a/result_eval.go
+++ b/result_eval.go
@@ -103,12 +103,12 @@ func evaluateDownloadedColumns(
 	bblock *spec.VersionedSignedBeaconBlock,
 	reqCols []uint64,
 	downloadedCols []*DataColumnSidecarV1,
-) (downloadedCells, validKzg []string, validColumn []bool, validSlot bool) {
+) ([]string, []string, []bool, bool) {
 	// define the evaluation result variables
-	downloadedCells = make([]string, len(reqCols))
-	validKzg = make([]string, len(reqCols))
-	validColumn = make([]bool, len(reqCols))
-	validSlot = true // true, unless something is not correct
+	downloadedCells := make([]string, len(reqCols))
+	validKzg := make([]string, len(reqCols))
+	validColumn := make([]bool, len(reqCols))
+	validSlot := true // true, unless something is not correct
 
 	// check if we could actually download anything from the
 	if bblock == nil {
@@ -121,15 +121,18 @@ func evaluateDownloadedColumns(
 		logger.Warnf("unable to retrieve kzg commitmets from bblock %d: %v", slot, err)
 		return downloadedCells, validKzg, validColumn, validSlot
 	}
-
-	// check each of the Columns
 	blobCount := len(kzgCommitments)
+	if blobCount == 0 {
+		return downloadedCells, validKzg, validColumn, validSlot
+	}
+	// check each of the Columns
 	// assume that all the cols are in order, and compare the kzg commitments from the bblock
 	// with the ones of the columns that we got throught the RPCs
 	for c := range reqCols {
 		downloadedCellsCount := 0
+		validCol := false
 		validKzgCount := 0
-		if c < len(downloadedCells) {
+		if c < len(downloadedCols) {
 			for _, cellKzg := range downloadedCols[c].KzgCommitments {
 				downloadedCellsCount++
 			kzgCheckLoop:
@@ -140,12 +143,13 @@ func evaluateDownloadedColumns(
 					}
 				}
 			}
+			// if we have as many valid KZG as blobs in the block -> is a valid column
+			validCol = (blobCount == validKzgCount)
 		}
 		downloadedCells[c] = fmt.Sprintf("%d/%d", downloadedCellsCount, blobCount)
 		validKzg[c] = fmt.Sprintf("%d/%d", validKzgCount, blobCount)
-		validCell := downloadedCellsCount == blobCount && validKzgCount == blobCount
-		validColumn[c] = validCell
-		if !validCell {
+		validColumn[c] = validCol
+		if !validCol {
 			validSlot = false
 		}
 	}

--- a/result_eval_test.go
+++ b/result_eval_test.go
@@ -1,0 +1,206 @@
+package dasguardian
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
+	"github.com/attestantio/go-eth2-client/spec/electra"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSingleSlotEvaluation(t *testing.T) {
+	tests := []struct {
+		tag                  string
+		slot                 uint64
+		bblock               *spec.VersionedSignedBeaconBlock
+		reqCols              []uint64
+		downloadedCols       []*DataColumnSidecarV1
+		expectedDownloads    []string
+		expectedValidKzgs    []string
+		expectedValidColumns []bool
+		expectedValidSlot    bool
+	}{
+		{
+			tag:     "columns downloaded and valid",
+			slot:    1,
+			bblock:  genSyntheticFuluBlock(1, 2),
+			reqCols: []uint64{1, 2, 3},
+			downloadedCols: []*DataColumnSidecarV1{
+				{
+					Index:          1,
+					KzgCommitments: generateSyntheticKzgBytes(2),
+					SignedBlockHeader: &phase0.SignedBeaconBlockHeader{
+						Message: &phase0.BeaconBlockHeader{
+							Slot: phase0.Slot(1),
+						},
+					},
+				},
+				{
+					Index:          2,
+					KzgCommitments: generateSyntheticKzgBytes(2),
+					SignedBlockHeader: &phase0.SignedBeaconBlockHeader{
+						Message: &phase0.BeaconBlockHeader{
+							Slot: phase0.Slot(1),
+						},
+					},
+				},
+				{
+					Index:          3,
+					KzgCommitments: generateSyntheticKzgBytes(2),
+					SignedBlockHeader: &phase0.SignedBeaconBlockHeader{
+						Message: &phase0.BeaconBlockHeader{
+							Slot: phase0.Slot(1),
+						},
+					},
+				},
+			},
+			expectedDownloads:    []string{"2/2", "2/2", "2/2"},
+			expectedValidKzgs:    []string{"2/2", "2/2", "2/2"},
+			expectedValidColumns: []bool{true, true, true},
+			expectedValidSlot:    true,
+		},
+		{
+			tag:     "columns downloaded but missing a column",
+			slot:    1,
+			bblock:  genSyntheticFuluBlock(1, 2),
+			reqCols: []uint64{1, 2, 3},
+			downloadedCols: []*DataColumnSidecarV1{
+				{
+					Index:          1,
+					KzgCommitments: generateSyntheticKzgBytes(2),
+					SignedBlockHeader: &phase0.SignedBeaconBlockHeader{
+						Message: &phase0.BeaconBlockHeader{
+							Slot: phase0.Slot(1),
+						},
+					},
+				},
+				{
+					Index:          2,
+					KzgCommitments: generateSyntheticKzgBytes(2),
+					SignedBlockHeader: &phase0.SignedBeaconBlockHeader{
+						Message: &phase0.BeaconBlockHeader{
+							Slot: phase0.Slot(1),
+						},
+					},
+				},
+			},
+			expectedDownloads:    []string{"2/2", "2/2", "0/2"},
+			expectedValidKzgs:    []string{"2/2", "2/2", "0/2"},
+			expectedValidColumns: []bool{true, true, false},
+			expectedValidSlot:    false,
+		},
+		{
+			tag:     "columns downloaded 1 incomplete",
+			slot:    1,
+			bblock:  genSyntheticFuluBlock(1, 2),
+			reqCols: []uint64{1, 2, 3},
+			downloadedCols: []*DataColumnSidecarV1{
+				{
+					Index:          1,
+					KzgCommitments: generateSyntheticKzgBytes(2),
+					SignedBlockHeader: &phase0.SignedBeaconBlockHeader{
+						Message: &phase0.BeaconBlockHeader{
+							Slot: phase0.Slot(1),
+						},
+					},
+				},
+				{
+					Index:          2,
+					KzgCommitments: generateSyntheticKzgBytes(2),
+					SignedBlockHeader: &phase0.SignedBeaconBlockHeader{
+						Message: &phase0.BeaconBlockHeader{
+							Slot: phase0.Slot(1),
+						},
+					},
+				},
+				{
+					Index:          3,
+					KzgCommitments: generateSyntheticKzgBytes(1),
+					SignedBlockHeader: &phase0.SignedBeaconBlockHeader{
+						Message: &phase0.BeaconBlockHeader{
+							Slot: phase0.Slot(1),
+						},
+					},
+				},
+			},
+			expectedDownloads:    []string{"2/2", "2/2", "1/2"},
+			expectedValidKzgs:    []string{"2/2", "2/2", "1/2"},
+			expectedValidColumns: []bool{true, true, false},
+			expectedValidSlot:    false,
+		},
+		{
+			tag:                  "no downloads",
+			slot:                 1,
+			bblock:               genSyntheticFuluBlock(1, 2),
+			reqCols:              []uint64{1, 2, 3},
+			downloadedCols:       []*DataColumnSidecarV1{},
+			expectedDownloads:    []string{"0/2", "0/2", "0/2"},
+			expectedValidKzgs:    []string{"0/2", "0/2", "0/2"},
+			expectedValidColumns: []bool{false, false, false},
+			expectedValidSlot:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.tag, func(t *testing.T) {
+			expDownloads, expValidKzg, validCols, validSlot := evaluateDownloadedColumns(
+				logrus.New(),
+				test.slot,
+				test.bblock,
+				test.reqCols,
+				test.downloadedCols,
+			)
+			assert.Equal(t, test.expectedValidSlot, validSlot)
+			for i := range validCols {
+				assert.Equal(t, test.expectedValidColumns[i], validCols[i])
+			}
+			for i := range expValidKzg {
+				assert.Equal(t, test.expectedValidKzgs[i], expValidKzg[i])
+			}
+			for i := range expDownloads {
+				assert.Equal(t, test.expectedDownloads[i], expDownloads[i])
+			}
+		})
+	}
+}
+
+func genSyntheticFuluBlock(slot uint64, blobs uint64) *spec.VersionedSignedBeaconBlock {
+	// create the minimal necessary beacon block
+	return &spec.VersionedSignedBeaconBlock{
+		Version: spec.DataVersionFulu,
+		Fulu: &electra.SignedBeaconBlock{
+			Message: &electra.BeaconBlock{
+				Slot: phase0.Slot(slot),
+				Body: &electra.BeaconBlockBody{
+					BlobKZGCommitments: generateSyntheticKzgs(blobs),
+				},
+			},
+		},
+	}
+}
+
+func generateSyntheticKzgs(kzgsCount uint64) []deneb.KZGCommitment {
+	kzgs := make([]deneb.KZGCommitment, kzgsCount)
+	for i := 0; i < int(kzgsCount); i++ {
+		kzgs[i] = generateSyntheticKzg(i)
+	}
+	return kzgs
+}
+
+func generateSyntheticKzg(kzgCount int) deneb.KZGCommitment {
+	kzg := make([]byte, 48)
+	kzg[kzgCount] = 1
+	return deneb.KZGCommitment(kzg[:48])
+}
+
+func generateSyntheticKzgBytes(kzgCount int) [][]byte {
+	kzgBytes := make([][]byte, kzgCount)
+	kzgs := generateSyntheticKzgs(uint64(kzgCount))
+	for i, kzg := range kzgs {
+		kzgBytes[i] = []byte(kzg[:])
+	}
+	return kzgBytes
+}

--- a/rpcs.go
+++ b/rpcs.go
@@ -53,13 +53,14 @@ func (r *ReqResp) Ping(ctx context.Context, pid peer.ID) (err error) {
 	return nil
 }
 
-func (r *ReqResp) GoodBye(ctx context.Context, pid peer.ID) (err error) {
+func (r *ReqResp) GoodBye(ctx context.Context, pid peer.ID, goodbyeCode uint64) (err error) {
 	stream, err := r.host.NewStream(ctx, pid, protocol.ID(RPCGoodByeTopicV1))
 	if err != nil {
 		return fmt.Errorf("new %s stream to peer %s: %w", RPCGoodByeTopicV1, pid, err)
 	}
 
-	req := uint64(1)
+	// make sure that we write the given code on goodbye
+	req := uint64(goodbyeCode)
 	if err := r.writeRequest(stream, &req); err != nil {
 		stream.Reset()
 		return fmt.Errorf("write goodbye request: %w", err)

--- a/rpcs.go
+++ b/rpcs.go
@@ -65,18 +65,7 @@ func (r *ReqResp) GoodBye(ctx context.Context, pid peer.ID, goodbyeCode uint64) 
 		stream.Reset()
 		return fmt.Errorf("write goodbye request: %w", err)
 	}
-
-	// read and decode goodbye response
-	resp := uint64(0)
-	if err := r.readResponse(stream, &resp); err != nil {
-		stream.Reset()
-		return fmt.Errorf("read goodbye response: %w", err)
-	}
-
-	// we have the data that we want, close stream cleanly
-	_ = stream.Close()
-
-	return nil
+	return stream.Close()
 }
 
 func (r *ReqResp) StatusV1(ctx context.Context, pid peer.ID, st *StatusV1) (status *StatusV1, err error) {


### PR DESCRIPTION
# Description
After #40, with the update of the result evaluation, I introduced a broken check that panics when das-guardian couldn't download anything from the remote node.

This PR does:
- fix that issue
- add some tests to recreate the most evaluation results 
- ensure that we send a goodbye message before disconnection
